### PR TITLE
feat: 아티클 생성로직 구현

### DIFF
--- a/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
@@ -1,0 +1,30 @@
+package com.pinback.pinback_server.domain.article.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pinback.pinback_server.domain.article.application.command.ArticleCreateCommand;
+import com.pinback.pinback_server.domain.article.domain.entity.Article;
+import com.pinback.pinback_server.domain.article.domain.service.ArticleSaveService;
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.category.domain.service.CategoryGetService;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ArticleManagementUsecase {
+
+	private final CategoryGetService categoryGetService;
+	private final ArticleSaveService articleSaveService;
+
+	//TODO: 리마인드 로직 추가 필요
+	//TODO: 자신의 카테고리가 아닐경우 예외처리
+	public void createArticle(User user, ArticleCreateCommand command) {
+		Category category = categoryGetService.getCategory(command.categoryId());
+		Article article = Article.create(command.url(), command.memo(), user, category);
+		articleSaveService.save(article);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
@@ -21,6 +21,7 @@ public class ArticleManagementUsecase {
 	private final ArticleSaveService articleSaveService;
 
 	//TODO: 리마인드 로직 추가 필요
+	@Transactional
 	public void createArticle(User user, ArticleCreateCommand command) {
 		Category category = categoryGetService.getCategoryAndUser(command.categoryId(), user);
 		Article article = Article.create(command.url(), command.memo(), user, category);

--- a/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
@@ -21,9 +21,8 @@ public class ArticleManagementUsecase {
 	private final ArticleSaveService articleSaveService;
 
 	//TODO: 리마인드 로직 추가 필요
-	//TODO: 자신의 카테고리가 아닐경우 예외처리
 	public void createArticle(User user, ArticleCreateCommand command) {
-		Category category = categoryGetService.getCategory(command.categoryId());
+		Category category = categoryGetService.getCategoryAndUser(command.categoryId(), user);
 		Article article = Article.create(command.url(), command.memo(), user, category);
 		articleSaveService.save(article);
 	}

--- a/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
@@ -5,7 +5,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.pinback.pinback_server.domain.article.application.command.ArticleCreateCommand;
 import com.pinback.pinback_server.domain.article.domain.entity.Article;
+import com.pinback.pinback_server.domain.article.domain.service.ArticleGetService;
 import com.pinback.pinback_server.domain.article.domain.service.ArticleSaveService;
+import com.pinback.pinback_server.domain.article.exception.ArticleAlreadyExistException;
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.category.domain.service.CategoryGetService;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
@@ -19,10 +21,14 @@ public class ArticleManagementUsecase {
 
 	private final CategoryGetService categoryGetService;
 	private final ArticleSaveService articleSaveService;
+	private final ArticleGetService articleGetService;
 
 	//TODO: 리마인드 로직 추가 필요
 	@Transactional
 	public void createArticle(User user, ArticleCreateCommand command) {
+		if (articleGetService.checkExistsByUserAndUrl(user, command.url())) {
+			throw new ArticleAlreadyExistException();
+		}
 		Category category = categoryGetService.getCategoryAndUser(command.categoryId(), user);
 		Article article = Article.create(command.url(), command.memo(), user, category);
 		articleSaveService.save(article);

--- a/src/main/java/com/pinback/pinback_server/domain/article/application/command/ArticleCreateCommand.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/application/command/ArticleCreateCommand.java
@@ -1,0 +1,11 @@
+package com.pinback.pinback_server.domain.article.application.command;
+
+import java.time.LocalDateTime;
+
+public record ArticleCreateCommand(
+	String url,
+	long categoryId,
+	String memo,
+	LocalDateTime remindTime
+) {
+}

--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/entity/Article.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/entity/Article.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,7 +22,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "article")
+@Table(name = "article", uniqueConstraints =
+@UniqueConstraint(
+	columnNames = {"user_id", "url"}
+))
 @Builder(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepository.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepository.java
@@ -4,7 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.pinback.pinback_server.domain.article.domain.entity.Article;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
 
 @Repository
 public interface ArticleRepository extends JpaRepository<Article, Long> {
+
+	boolean existsByUserAndUrl(User user, String url);
 }

--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/service/ArticleGetService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/service/ArticleGetService.java
@@ -1,0 +1,20 @@
+package com.pinback.pinback_server.domain.article.domain.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pinback.pinback_server.domain.article.domain.repository.ArticleRepository;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ArticleGetService {
+	private final ArticleRepository articleRepository;
+
+	public boolean checkExistsByUserAndUrl(User user, String url) {
+		return articleRepository.existsByUserAndUrl(user, url);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/service/ArticleSaveService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/service/ArticleSaveService.java
@@ -1,0 +1,20 @@
+package com.pinback.pinback_server.domain.article.domain.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pinback.pinback_server.domain.article.domain.entity.Article;
+import com.pinback.pinback_server.domain.article.domain.repository.ArticleRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ArticleSaveService {
+	private final ArticleRepository articleRepository;
+
+	public void save(Article article) {
+		articleRepository.save(article);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/article/exception/ArticleAlreadyExistException.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/exception/ArticleAlreadyExistException.java
@@ -1,0 +1,10 @@
+package com.pinback.pinback_server.domain.article.exception;
+
+import com.pinback.pinback_server.global.exception.ApplicationException;
+import com.pinback.pinback_server.global.exception.constant.ExceptionCode;
+
+public class ArticleAlreadyExistException extends ApplicationException {
+	public ArticleAlreadyExistException() {
+		super(ExceptionCode.ARTICLE_ALREADY_EXIST);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/article/presentation/ArticleController.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/presentation/ArticleController.java
@@ -1,0 +1,28 @@
+package com.pinback.pinback_server.domain.article.presentation;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pinback.pinback_server.domain.article.application.ArticleManagementUsecase;
+import com.pinback.pinback_server.domain.article.presentation.dto.request.ArticleCreateRequest;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
+import com.pinback.pinback_server.global.common.annotation.CurrentUser;
+import com.pinback.pinback_server.global.common.dto.ResponseDto;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/article")
+@RequiredArgsConstructor
+public class ArticleController {
+	private final ArticleManagementUsecase articleManagementUsecase;
+
+	@PostMapping
+	public ResponseDto<Void> createArticle(@CurrentUser User user, @Valid @RequestBody ArticleCreateRequest request) {
+		articleManagementUsecase.createArticle(user, request.toCommand());
+		return ResponseDto.created();
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/article/presentation/dto/request/ArticleCreateRequest.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/presentation/dto/request/ArticleCreateRequest.java
@@ -1,0 +1,30 @@
+package com.pinback.pinback_server.domain.article.presentation.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.pinback.pinback_server.domain.article.application.command.ArticleCreateCommand;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record ArticleCreateRequest(
+	@NotEmpty(message = "url을 비어있을 수 없습니다.")
+	String url,
+
+	@NotNull(message = "카테고리 ID는 비어있을 수 없습니다.")
+	Long categoryId,
+	
+	String memo,
+
+	@NotNull(message = "리마인드 날짜는 비어있을 수 없습니다.")
+	LocalDateTime remindTime
+) {
+	public ArticleCreateCommand toCommand() {
+		return new ArticleCreateCommand(
+			url,
+			categoryId,
+			memo,
+			remindTime
+		);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepository.java
@@ -1,10 +1,14 @@
 package com.pinback.pinback_server.domain.category.domain.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+	Optional<Category> findByIdAndUser(long categoryId, User user);
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.category.domain.repository.CategoryRepository;
 import com.pinback.pinback_server.domain.category.exception.CategoryNotFoundException;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class CategoryGetService {
 	private final CategoryRepository categoryRepository;
 
-	public Category getCategory(long categoryId) {
-		return categoryRepository.findById(categoryId).orElseThrow(CategoryNotFoundException::new);
+	public Category getCategoryAndUser(long categoryId, User user) {
+		return categoryRepository.findByIdAndUser(categoryId, user).orElseThrow(CategoryNotFoundException::new);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetService.java
@@ -1,0 +1,21 @@
+package com.pinback.pinback_server.domain.category.domain.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.category.domain.repository.CategoryRepository;
+import com.pinback.pinback_server.domain.category.exception.CategoryNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CategoryGetService {
+	private final CategoryRepository categoryRepository;
+
+	public Category getCategory(long categoryId) {
+		return categoryRepository.findById(categoryId).orElseThrow(CategoryNotFoundException::new);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/exception/CategoryNotFoundException.java
@@ -1,0 +1,10 @@
+package com.pinback.pinback_server.domain.category.exception;
+
+import com.pinback.pinback_server.global.exception.ApplicationException;
+import com.pinback.pinback_server.global.exception.constant.ExceptionCode;
+
+public class CategoryNotFoundException extends ApplicationException {
+	public CategoryNotFoundException() {
+		super(ExceptionCode.CATEGORY_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/global/exception/constant/ExceptionCode.java
+++ b/src/main/java/com/pinback/pinback_server/global/exception/constant/ExceptionCode.java
@@ -10,7 +10,7 @@ public enum ExceptionCode {
 	//400
 	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "c40000", "잘못된 요청입니다."),
 
-	//403
+	//401
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "c40101", "유효하지 않은 토큰입니다."),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "c40102", "만료된 토큰입니다."),
 	EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "c40101", "토큰이 비어있습니다."),

--- a/src/main/java/com/pinback/pinback_server/global/exception/constant/ExceptionCode.java
+++ b/src/main/java/com/pinback/pinback_server/global/exception/constant/ExceptionCode.java
@@ -26,6 +26,7 @@ public enum ExceptionCode {
 	//409
 	DUPLICATE(HttpStatus.CONFLICT, "c40900", "이미 존재하는 리소스입니다."),
 	USER_ALREADY_EXIST(HttpStatus.CONFLICT, "c40901", "이미 존재하는 사용자입니다."),
+	ARTICLE_ALREADY_EXIST(HttpStatus.CONFLICT, "c40902", "이미 저장한 url 입니다."),
 
 	//500
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "s50000", "서버 내부 오류가 발생했습니다.");

--- a/src/main/java/com/pinback/pinback_server/global/exception/constant/ExceptionCode.java
+++ b/src/main/java/com/pinback/pinback_server/global/exception/constant/ExceptionCode.java
@@ -17,7 +17,8 @@ public enum ExceptionCode {
 
 	//404
 	NOT_FOUND(HttpStatus.NOT_FOUND, "c40400", "리소스가 존재하지 않습니다."),
-	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "c40400", "사용자가 존재하지 않습니다."),
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "c40401", "사용자가 존재하지 않습니다."),
+	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "c40402", "카테고리가 존재하지 않습니다."),
 
 	//405
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "c40500", "잘못된 HTTP method 요청입니다."),

--- a/src/test/java/com/pinback/pinback_server/domain/ApplicationTest.java
+++ b/src/test/java/com/pinback/pinback_server/domain/ApplicationTest.java
@@ -1,0 +1,21 @@
+package com.pinback.pinback_server.domain;
+
+import org.junit.jupiter.api.AfterEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.pinback.pinback_server.domain.fixture.CustomRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class ApplicationTest {
+
+	@Autowired
+	CustomRepository customRepository;
+
+	@AfterEach
+	void tearDown() {
+		customRepository.clearAndReset();
+	}
+}

--- a/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecaseTest.java
+++ b/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecaseTest.java
@@ -1,0 +1,56 @@
+package com.pinback.pinback_server.domain.article.application;
+
+import static com.pinback.pinback_server.domain.fixture.TestFixture.*;
+
+import java.time.LocalDateTime;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pinback.pinback_server.domain.article.application.command.ArticleCreateCommand;
+import com.pinback.pinback_server.domain.article.domain.entity.Article;
+import com.pinback.pinback_server.domain.article.domain.repository.ArticleRepository;
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.category.domain.repository.CategoryRepository;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
+import com.pinback.pinback_server.domain.user.domain.repository.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class ArticleManagementUsecaseTest {
+
+	@Autowired
+	private ArticleManagementUsecase articleManagementUsecase;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private ArticleRepository articleRepository;
+
+	@DisplayName("사용자는 아티클을 생성할 수 있다.")
+	@Test
+	void articleSaveService() {
+		User user = userRepository.save(user());
+		Category category = categoryRepository.save(category(user));
+		ArticleCreateCommand command = new ArticleCreateCommand("testUrl", category.getId()
+			, "테스트메모",
+			LocalDateTime.of(2025, 8, 6, 0, 0, 0));
+		//when
+		articleManagementUsecase.createArticle(user, command);
+
+		//then
+		Article article = articleRepository.findById(1L).get();
+		Assertions.assertThat(article.getUrl()).isEqualTo(command.url());
+		Assertions.assertThat(article.getMemo()).isEqualTo(command.memo());
+		Assertions.assertThat(article.getCategory()).isEqualTo(category);
+		Assertions.assertThat(article.getIsRead()).isFalse();
+	}
+
+}

--- a/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecaseTest.java
+++ b/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecaseTest.java
@@ -52,5 +52,4 @@ class ArticleManagementUsecaseTest {
 		Assertions.assertThat(article.getCategory()).isEqualTo(category);
 		Assertions.assertThat(article.getIsRead()).isFalse();
 	}
-
 }

--- a/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecaseTest.java
+++ b/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecaseTest.java
@@ -1,10 +1,10 @@
 package com.pinback.pinback_server.domain.article.application;
 
 import static com.pinback.pinback_server.domain.fixture.TestFixture.*;
+import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDateTime;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,9 +12,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.pinback.pinback_server.domain.ApplicationTest;
 import com.pinback.pinback_server.domain.article.application.command.ArticleCreateCommand;
 import com.pinback.pinback_server.domain.article.domain.entity.Article;
 import com.pinback.pinback_server.domain.article.domain.repository.ArticleRepository;
+import com.pinback.pinback_server.domain.article.exception.ArticleAlreadyExistException;
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.category.domain.repository.CategoryRepository;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
@@ -23,7 +25,7 @@ import com.pinback.pinback_server.domain.user.domain.repository.UserRepository;
 @SpringBootTest
 @ActiveProfiles("test")
 @Transactional
-class ArticleManagementUsecaseTest {
+class ArticleManagementUsecaseTest extends ApplicationTest {
 
 	@Autowired
 	private ArticleManagementUsecase articleManagementUsecase;
@@ -47,9 +49,24 @@ class ArticleManagementUsecaseTest {
 
 		//then
 		Article article = articleRepository.findById(1L).get();
-		Assertions.assertThat(article.getUrl()).isEqualTo(command.url());
-		Assertions.assertThat(article.getMemo()).isEqualTo(command.memo());
-		Assertions.assertThat(article.getCategory()).isEqualTo(category);
-		Assertions.assertThat(article.getIsRead()).isFalse();
+		assertThat(article.getUrl()).isEqualTo(command.url());
+		assertThat(article.getMemo()).isEqualTo(command.memo());
+		assertThat(article.getCategory()).isEqualTo(category);
+		assertThat(article.getIsRead()).isFalse();
+	}
+
+	@DisplayName("사용자는 중복된 url을 저장할 수 없다.")
+	@Test
+	void articleDuplicate() {
+		User user = userRepository.save(user());
+		Category category = categoryRepository.save(category(user));
+		Article article = articleRepository.save(articleWithCategory(user, category));
+		ArticleCreateCommand command = new ArticleCreateCommand(article.getUrl(), article.getCategory().getId()
+			, article.getMemo(),
+			LocalDateTime.of(2025, 8, 6, 0, 0, 0));
+		//when & then
+		assertThatThrownBy(() -> articleManagementUsecase.createArticle(user, command))
+			.isInstanceOf(ArticleAlreadyExistException.class);
+
 	}
 }

--- a/src/test/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetServiceTest.java
+++ b/src/test/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetServiceTest.java
@@ -1,0 +1,47 @@
+package com.pinback.pinback_server.domain.category.domain.service;
+
+import static com.pinback.pinback_server.domain.fixture.TestFixture.*;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.category.domain.repository.CategoryRepository;
+import com.pinback.pinback_server.domain.category.exception.CategoryNotFoundException;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
+import com.pinback.pinback_server.domain.user.domain.repository.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class CategoryGetServiceTest {
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private CategoryRepository categoryRepository;
+
+	@Autowired
+	private CategoryGetService categoryGetService;
+
+	@DisplayName("카테고리 소유자가 아닐경우 예외가 발생한다.")
+	@Test
+	void throwExceptionIsNotOwner() {
+		//given
+		User user = userRepository.save(user());
+		User user1 = userRepository.save(userWithEmail("another@gmail.com"));
+		Category category = categoryRepository.save(category(user));
+
+		//when & Then
+
+		Assertions.assertThatThrownBy(() -> categoryGetService.getCategoryAndUser(category.getId(), user1))
+			.isInstanceOf(CategoryNotFoundException.class);
+
+	}
+
+}

--- a/src/test/java/com/pinback/pinback_server/domain/fixture/CustomRepository.java
+++ b/src/test/java/com/pinback/pinback_server/domain/fixture/CustomRepository.java
@@ -1,0 +1,23 @@
+package com.pinback.pinback_server.domain.fixture;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+
+@Repository
+public class CustomRepository {
+	@Autowired
+	private EntityManager entityManager;
+
+	@Transactional
+	public void clearAndReset() {
+		entityManager.createNativeQuery("DELETE FROM article").executeUpdate();
+		entityManager.createNativeQuery("DELETE FROM category").executeUpdate();
+		entityManager.createNativeQuery("DELETE FROM users").executeUpdate();
+
+		entityManager.createNativeQuery("ALTER TABLE article ALTER COLUMN article_id RESTART WITH 1").executeUpdate();
+		entityManager.createNativeQuery("ALTER TABLE category ALTER COLUMN category_id RESTART WITH 1").executeUpdate();
+	}
+}

--- a/src/test/java/com/pinback/pinback_server/domain/fixture/TestFixture.java
+++ b/src/test/java/com/pinback/pinback_server/domain/fixture/TestFixture.java
@@ -11,6 +11,10 @@ public class TestFixture {
 		return User.create("testUser@gmail.com", LocalTime.of(12, 0, 0));
 	}
 
+	public static User userWithEmail(String email) {
+		return User.create(email, LocalTime.of(12, 0, 0));
+	}
+
 	public static Category category(User user) {
 		return Category.create("테스트카테고리", user);
 	}

--- a/src/test/java/com/pinback/pinback_server/domain/fixture/TestFixture.java
+++ b/src/test/java/com/pinback/pinback_server/domain/fixture/TestFixture.java
@@ -2,6 +2,7 @@ package com.pinback.pinback_server.domain.fixture;
 
 import java.time.LocalTime;
 
+import com.pinback.pinback_server.domain.article.domain.entity.Article;
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
 
@@ -17,5 +18,14 @@ public class TestFixture {
 
 	public static Category category(User user) {
 		return Category.create("테스트카테고리", user);
+	}
+
+	public static Article article(User user) {
+		Category category = category(user);
+		return Article.create("test", "testmemo", user, category);
+	}
+
+	public static Article articleWithCategory(User user, Category category) {
+		return Article.create("test", "testmemo", user, category);
 	}
 }

--- a/src/test/java/com/pinback/pinback_server/domain/fixture/TestFixture.java
+++ b/src/test/java/com/pinback/pinback_server/domain/fixture/TestFixture.java
@@ -1,0 +1,17 @@
+package com.pinback.pinback_server.domain.fixture;
+
+import java.time.LocalTime;
+
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
+
+public class TestFixture {
+
+	public static User user() {
+		return User.create("testUser@gmail.com", LocalTime.of(12, 0, 0));
+	}
+
+	public static Category category(User user) {
+		return Category.create("테스트카테고리", user);
+	}
+}


### PR DESCRIPTION
## 🚀 PR 요약

아티클 생성 로직을 구현했습니다

## ✨ PR 상세 내용

1. 리마인드 생성은 없는 순수하게 생성하는 로직으로 구현했습니다
2. 아티클 생성시 인당 같은 url은 하나만 가질 수 있기 때문에 도메인에 uniqueKey를 걸었습니다 f1f66a66d8508f0b086b9af9a8534731ecdd14a3
3. 미리 중복 url을 검증할 수 있는 로직을 만들었습니다
4. 현재 가진 카테고리가 존재하지 않을 경우 예외를 처리했습니다. 
5. 원활한 테스트를 위해 testFixture를 만들었습니다.
6. 테스트 일관성을 위해 ApplicationTest 클래스를 만들었습니다.  f9c40620b786251f67de7e32ab8a795cdd7aaad6

## 🚨 주의 사항

주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?

close #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to create articles with URL, category, memo, and reminder time, including validation and duplicate checks.
  * Introduced a new endpoint for article creation.
  * Implemented error handling for duplicate articles and missing categories.

* **Bug Fixes**
  * Enforced uniqueness for articles based on user and URL to prevent duplicates.

* **Tests**
  * Added comprehensive tests for article creation, duplicate handling, and category ownership validation.
  * Introduced utilities for test data setup and database cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->