### PR TITLE
feat: 카테고리 생성 기능 구현

### DIFF
--- a/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
@@ -1,0 +1,31 @@
+package com.pinback.pinback_server.domain.category.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pinback.pinback_server.domain.category.application.command.CategoryCreateCommand;
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.category.domain.service.CategoryGetService;
+import com.pinback.pinback_server.domain.category.domain.service.CategorySaveService;
+import com.pinback.pinback_server.domain.category.exception.CategoryAlreadyExistException;
+import com.pinback.pinback_server.domain.category.presentation.dto.response.CreateCategoryResponse;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryManagementUsecase {
+	private final CategorySaveService categorySaveService;
+	private final CategoryGetService categoryGetService;
+
+	@Transactional
+	public CreateCategoryResponse createCategory(User user, CategoryCreateCommand command) {
+		if (categoryGetService.checkExistsByCategoryNameAndUser(command.CategoryName(), user)) {
+			throw new CategoryAlreadyExistException();
+		}
+		Category category = Category.create(command.CategoryName(), user);
+		Category savedCategory = categorySaveService.save(category);
+		return CreateCategoryResponse.of(savedCategory.getId(), savedCategory.getName());
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
@@ -8,6 +8,7 @@ import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.category.domain.service.CategoryGetService;
 import com.pinback.pinback_server.domain.category.domain.service.CategorySaveService;
 import com.pinback.pinback_server.domain.category.exception.CategoryAlreadyExistException;
+import com.pinback.pinback_server.domain.category.exception.CategoryLimitOverEception;
 import com.pinback.pinback_server.domain.category.presentation.dto.response.CreateCategoryResponse;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
 
@@ -16,11 +17,17 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class CategoryManagementUsecase {
+	private static final int MAX_CATEGORY_LIMIT = 10;
 	private final CategorySaveService categorySaveService;
 	private final CategoryGetService categoryGetService;
 
 	@Transactional
 	public CreateCategoryResponse createCategory(User user, CategoryCreateCommand command) {
+		long existingCategoryCnt = categoryGetService.countCategoriesByUser(user);
+		if (existingCategoryCnt >= MAX_CATEGORY_LIMIT) {
+			throw new CategoryLimitOverEception();
+		}
+
 		if (categoryGetService.checkExistsByCategoryNameAndUser(command.CategoryName(), user)) {
 			throw new CategoryAlreadyExistException();
 		}

--- a/src/main/java/com/pinback/pinback_server/domain/category/application/command/CategoryCreateCommand.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/application/command/CategoryCreateCommand.java
@@ -1,0 +1,6 @@
+package com.pinback.pinback_server.domain.category.application.command;
+
+public record CategoryCreateCommand(
+	String CategoryName
+) {
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepository.java
@@ -13,4 +13,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 	Optional<Category> findByIdAndUser(long categoryId, User user);
 
 	boolean existsByNameAndUser(String categoryName, User user);
+
+	long countByUser(User user);
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepository.java
@@ -11,4 +11,6 @@ import com.pinback.pinback_server.domain.user.domain.entity.User;
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 	Optional<Category> findByIdAndUser(long categoryId, User user);
+
+	boolean existsByNameAndUser(String categoryName, User user);
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetService.java
@@ -23,4 +23,8 @@ public class CategoryGetService {
 	public boolean checkExistsByCategoryNameAndUser(String categoryName, User user) {
 		return categoryRepository.existsByNameAndUser(categoryName, user);
 	}
+
+	public long countCategoriesByUser(User user) {
+		return categoryRepository.countByUser(user);
+	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetService.java
@@ -19,4 +19,8 @@ public class CategoryGetService {
 	public Category getCategoryAndUser(long categoryId, User user) {
 		return categoryRepository.findByIdAndUser(categoryId, user).orElseThrow(CategoryNotFoundException::new);
 	}
+
+	public boolean checkExistsByCategoryNameAndUser(String categoryName, User user) {
+		return categoryRepository.existsByNameAndUser(categoryName, user);
+	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategorySaveService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategorySaveService.java
@@ -1,0 +1,20 @@
+package com.pinback.pinback_server.domain.category.domain.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.category.domain.repository.CategoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CategorySaveService {
+	private final CategoryRepository categoryRepository;
+
+	public Category save(Category category) {
+		return categoryRepository.save(category);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/exception/CategoryAlreadyExistException.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/exception/CategoryAlreadyExistException.java
@@ -1,0 +1,10 @@
+package com.pinback.pinback_server.domain.category.exception;
+
+import com.pinback.pinback_server.global.exception.ApplicationException;
+import com.pinback.pinback_server.global.exception.constant.ExceptionCode;
+
+public class CategoryAlreadyExistException extends ApplicationException {
+	public CategoryAlreadyExistException() {
+		super(ExceptionCode.CATEGORY_ALREADY_EXIST);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/exception/CategoryLimitOverEception.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/exception/CategoryLimitOverEception.java
@@ -1,0 +1,11 @@
+package com.pinback.pinback_server.domain.category.exception;
+
+import com.pinback.pinback_server.global.exception.ApplicationException;
+import com.pinback.pinback_server.global.exception.constant.ExceptionCode;
+
+public class CategoryLimitOverEception extends ApplicationException {
+	public CategoryLimitOverEception() {
+		super(ExceptionCode.CATEGORY_LIMIT_OVER);
+
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/presentation/CategoryController.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/presentation/CategoryController.java
@@ -1,0 +1,31 @@
+package com.pinback.pinback_server.domain.category.presentation;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pinback.pinback_server.domain.category.application.CategoryManagementUsecase;
+import com.pinback.pinback_server.domain.category.presentation.dto.request.CategoryCreateRequest;
+import com.pinback.pinback_server.domain.category.presentation.dto.response.CreateCategoryResponse;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
+import com.pinback.pinback_server.global.common.annotation.CurrentUser;
+import com.pinback.pinback_server.global.common.dto.ResponseDto;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+	private final CategoryManagementUsecase categoryManagementUsecase;
+
+	@PostMapping
+	public ResponseDto<CreateCategoryResponse> createCategory(@CurrentUser User user,
+		@Valid @RequestBody CategoryCreateRequest request) {
+		CreateCategoryResponse response = categoryManagementUsecase.createCategory(user, request.toCommand());
+
+		return ResponseDto.created(response);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/request/CategoryCreateRequest.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/request/CategoryCreateRequest.java
@@ -1,0 +1,14 @@
+package com.pinback.pinback_server.domain.category.presentation.dto.request;
+
+import com.pinback.pinback_server.domain.category.application.command.CategoryCreateCommand;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CategoryCreateRequest(
+	@NotBlank(message = "카테고리 이름은 비어있을 수 없습니다.")
+	String categoryName
+) {
+	public CategoryCreateCommand toCommand() {
+		return new CategoryCreateCommand(categoryName);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/CreateCategoryResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/CreateCategoryResponse.java
@@ -1,0 +1,10 @@
+package com.pinback.pinback_server.domain.category.presentation.dto.response;
+
+public record CreateCategoryResponse(
+	Long id,
+	String categoryName
+) {
+	public static CreateCategoryResponse of(Long id, String categoryName) {
+		return new CreateCategoryResponse(id, categoryName);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/global/exception/constant/ExceptionCode.java
+++ b/src/main/java/com/pinback/pinback_server/global/exception/constant/ExceptionCode.java
@@ -28,6 +28,7 @@ public enum ExceptionCode {
 	DUPLICATE(HttpStatus.CONFLICT, "c40900", "이미 존재하는 리소스입니다."),
 	USER_ALREADY_EXIST(HttpStatus.CONFLICT, "c40901", "이미 존재하는 사용자입니다."),
 	ARTICLE_ALREADY_EXIST(HttpStatus.CONFLICT, "c40902", "이미 저장한 url 입니다."),
+	CATEGORY_ALREADY_EXIST(HttpStatus.CONFLICT, "c40903", "이미 존재하는 카테고리입니다."),
 
 	//500
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "s50000", "서버 내부 오류가 발생했습니다.");

--- a/src/main/java/com/pinback/pinback_server/global/exception/constant/ExceptionCode.java
+++ b/src/main/java/com/pinback/pinback_server/global/exception/constant/ExceptionCode.java
@@ -9,6 +9,7 @@ public enum ExceptionCode {
 
 	//400
 	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "c40000", "잘못된 요청입니다."),
+	CATEGORY_LIMIT_OVER(HttpStatus.BAD_REQUEST, "c40001", "카테고리는 최대 10개까지 생성할 수 있습니다."),
 
 	//401
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "c40101", "유효하지 않은 토큰입니다."),


### PR DESCRIPTION
## 🚀 PR 요약

카테고리 생성 기능을 구현합니다.

## ✨ PR 상세 내용

- [ ] 카테고리 생성 기능 구현
- [ ] 카테고리 이름 글자수 제한
- [ ] 카테고리 최대 생성 개수 10개로 제한

카테고리 이름 글자수 제한은 아직 기능 명세가 확실하지 않아서 추후 구현 예정입니다.

## 🚨 주의 사항



## ✅ 체크 리스트

- [ ] 리뷰어 설정했나요?
- [ ] Label 설정했나요?
- [ ] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트를 진행했나요?
