### PR TITLE
fix: soft delete 삭제

### DIFF
--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepositoryCustomImpl.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Repository;
 
 import com.pinback.pinback_server.domain.article.domain.entity.Article;
 import com.pinback.pinback_server.domain.article.domain.repository.dto.ArticlesWithUnreadCount;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -26,10 +27,13 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
 
 	@Override
 	public ArticlesWithUnreadCount findAllCustom(UUID userId, Pageable pageable) {
+
+		BooleanExpression conditions = article.user.id.eq(userId);
+
 		List<Article> articles = queryFactory
 			.selectFrom(article)
 			.join(article.user, user).fetchJoin()
-			.where(article.user.id.eq(userId))
+			.where(conditions)
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.orderBy(article.createdAt.desc())
@@ -38,12 +42,12 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
 		JPAQuery<Long> countQuery = queryFactory
 			.select(article.count())
 			.from(article)
-			.where(article.user.id.eq(userId));
+			.where(conditions);
 
 		Long unReadCount = queryFactory
 			.select(article.count())
 			.from(article)
-			.where(article.user.id.eq(userId).and(article.isRead.isFalse()))
+			.where(conditions.and(article.isRead.isFalse()))
 			.fetchOne();
 
 		return new ArticlesWithUnreadCount(unReadCount,
@@ -53,10 +57,12 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
 	@Override
 	public ArticlesWithUnreadCount findAllByCategory(UUID userId, long categoryId, Pageable pageable) {
 
+		BooleanExpression conditions = article.category.id.eq(categoryId);
+
 		List<Article> articles = queryFactory
 			.selectFrom(article)
 			.join(article.category, category).fetchJoin()
-			.where(article.category.id.eq(categoryId))
+			.where(conditions)
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.orderBy(article.createdAt.desc())
@@ -65,12 +71,12 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
 		JPAQuery<Long> countQuery = queryFactory
 			.select(article.count())
 			.from(article)
-			.where(article.category.id.eq(categoryId));
+			.where(conditions);
 
 		Long unReadCount = queryFactory
 			.select(article.count())
 			.from(article)
-			.where(article.category.id.eq(categoryId).and(article.isRead.isFalse()))
+			.where(conditions.and(article.isRead.isFalse()))
 			.fetchOne();
 
 		return new ArticlesWithUnreadCount(unReadCount,

--- a/src/main/java/com/pinback/pinback_server/global/entity/BaseEntity.java
+++ b/src/main/java/com/pinback/pinback_server/global/entity/BaseEntity.java
@@ -2,8 +2,6 @@ package com.pinback.pinback_server.global.entity;
 
 import java.time.LocalDateTime;
 
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -16,8 +14,6 @@ import lombok.Getter;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-@SQLDelete(sql = "UPDATE category SET deleted = true WHERE id = ?")
-@SQLRestriction("deleted = false")
 public class BaseEntity {
 	@Column(name = "created_at")
 	@CreatedDate
@@ -26,7 +22,4 @@ public class BaseEntity {
 	@Column(name = "updated_at")
 	@LastModifiedDate
 	private LocalDateTime updatedAt;
-
-	@Column(name = "deleted_at", nullable = false)
-	private boolean isDeleted;
 }


### PR DESCRIPTION
## 🚀 PR 요약

close #28 soft delete 를 구현하려 했는데 자동으로 적용이 되지 않아 hard delete로 변경했습니다.

## ✨ PR 상세 내용

soft delete 필드 삭제

## 🚨 주의 사항

없습니다

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved query readability and maintainability by consolidating filtering conditions in article-related queries.

* **Chores**
  * Removed soft delete functionality from the system; entities will no longer be marked or filtered as deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->