### PR TITLE
feat: 카테고리 전체 조회 구현

### DIFF
--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepository.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepository.java
@@ -1,6 +1,10 @@
 package com.pinback.pinback_server.domain.article.domain.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.pinback.pinback_server.domain.article.domain.entity.Article;
@@ -10,4 +14,7 @@ import com.pinback.pinback_server.domain.user.domain.entity.User;
 public interface ArticleRepository extends JpaRepository<Article, Long>, ArticleRepositoryCustom {
 
 	boolean existsByUserAndUrl(User user, String url);
+
+	@Query("SELECT a FROM Article a WHERE a.user = :user ORDER BY a.createdAt DESC LIMIT 1")
+	Optional<Article> findRecentArticleByUser(@Param("user") User user);
 }

--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/service/ArticleGetService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/service/ArticleGetService.java
@@ -1,5 +1,6 @@
 package com.pinback.pinback_server.domain.article.domain.service;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.PageRequest;
@@ -35,5 +36,9 @@ public class ArticleGetService {
 
 	public ArticlesWithUnreadCount findAllByCategory(UUID userId, Category category, PageRequest pageRequest) {
 		return articleRepository.findAllByCategory(userId, category.getId(), pageRequest);
+	}
+
+	public Optional<Article> findRecentByUser(User user) {
+		return articleRepository.findRecentArticleByUser(user);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
@@ -10,12 +10,15 @@ import com.pinback.pinback_server.domain.article.domain.entity.Article;
 import com.pinback.pinback_server.domain.article.domain.service.ArticleGetService;
 import com.pinback.pinback_server.domain.category.application.command.CategoryCreateCommand;
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForDashboard;
 import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForExtension;
 import com.pinback.pinback_server.domain.category.domain.service.CategoryGetService;
 import com.pinback.pinback_server.domain.category.domain.service.CategorySaveService;
 import com.pinback.pinback_server.domain.category.exception.CategoryAlreadyExistException;
 import com.pinback.pinback_server.domain.category.exception.CategoryLimitOverException;
+import com.pinback.pinback_server.domain.category.presentation.dto.response.CategoryAllDashboardResponse;
 import com.pinback.pinback_server.domain.category.presentation.dto.response.CategoryAllExtensionResponse;
+import com.pinback.pinback_server.domain.category.presentation.dto.response.CategoryDashboardResponse;
 import com.pinback.pinback_server.domain.category.presentation.dto.response.CategoryExtensionResponse;
 import com.pinback.pinback_server.domain.category.presentation.dto.response.CreateCategoryResponse;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
@@ -65,5 +68,16 @@ public class CategoryManagementUsecase {
 			.toList();
 
 		return CategoryAllExtensionResponse.of(recentSaved, response);
+	}
+
+	@Transactional(readOnly = true)
+	public CategoryAllDashboardResponse getAllCategoriesDashboard(User user) {
+		CategoriesForDashboard projection = categoryGetService.findAllForDashboard(user.getId());
+		List<CategoryDashboardResponse> response = projection.getCategories().stream()
+			.map(category -> new CategoryDashboardResponse(category.getId(), category.getName(),
+				category.getUnreadCount()))
+			.toList();
+
+		return CategoryAllDashboardResponse.of(response);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
@@ -1,14 +1,22 @@
 package com.pinback.pinback_server.domain.category.application;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.pinback.pinback_server.domain.article.domain.entity.Article;
+import com.pinback.pinback_server.domain.article.domain.service.ArticleGetService;
 import com.pinback.pinback_server.domain.category.application.command.CategoryCreateCommand;
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForExtension;
 import com.pinback.pinback_server.domain.category.domain.service.CategoryGetService;
 import com.pinback.pinback_server.domain.category.domain.service.CategorySaveService;
 import com.pinback.pinback_server.domain.category.exception.CategoryAlreadyExistException;
 import com.pinback.pinback_server.domain.category.exception.CategoryLimitOverException;
+import com.pinback.pinback_server.domain.category.presentation.dto.response.CategoryAllExtensionResponse;
+import com.pinback.pinback_server.domain.category.presentation.dto.response.CategoryExtensionResponse;
 import com.pinback.pinback_server.domain.category.presentation.dto.response.CreateCategoryResponse;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
 
@@ -22,6 +30,7 @@ public class CategoryManagementUsecase {
 	private static final int CATEGORY_LIMIT = 10;
 	private final CategorySaveService categorySaveService;
 	private final CategoryGetService categoryGetService;
+	private final ArticleGetService articleGetService;
 
 	@Transactional
 	public CreateCategoryResponse createCategory(User user, CategoryCreateCommand command) {
@@ -33,9 +42,28 @@ public class CategoryManagementUsecase {
 		if (categoryGetService.checkExistsByCategoryNameAndUser(command.categoryName(), user)) {
 			throw new CategoryAlreadyExistException();
 		}
-		
+
 		Category category = Category.create(command.categoryName(), user);
 		Category savedCategory = categorySaveService.save(category);
 		return CreateCategoryResponse.of(savedCategory.getId(), savedCategory.getName());
+	}
+
+	@Transactional(readOnly = true)
+	public CategoryAllExtensionResponse getAllCategoriesExtension(User user) {
+		Optional<Article> articleOptional = articleGetService.findRecentByUser(user);
+		String recentSaved = null;
+		if (articleOptional.isPresent()) {
+			Article article = articleOptional.get();
+
+			if (article.getCategory() != null) {
+				recentSaved = article.getCategory().getName();
+			}
+		}
+		CategoriesForExtension projection = categoryGetService.findAllForExtension(user.getId());
+		List<CategoryExtensionResponse> response = projection.getCategories().stream()
+			.map(c -> new CategoryExtensionResponse(c.getId(), c.getName()))
+			.toList();
+
+		return CategoryAllExtensionResponse.of(recentSaved, response);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
@@ -57,10 +57,7 @@ public class CategoryManagementUsecase {
 		String recentSaved = null;
 		if (articleOptional.isPresent()) {
 			Article article = articleOptional.get();
-
-			if (article.getCategory() != null) {
-				recentSaved = article.getCategory().getName();
-			}
+			recentSaved = article.getCategory().getName();
 		}
 		CategoriesForExtension projection = categoryGetService.findAllForExtension(user.getId());
 		List<CategoryExtensionResponse> response = projection.getCategories().stream()

--- a/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
@@ -64,7 +64,7 @@ public class CategoryManagementUsecase {
 		}
 		CategoriesForExtension projection = categoryGetService.findAllForExtension(user.getId());
 		List<CategoryExtensionResponse> response = projection.getCategories().stream()
-			.map(c -> new CategoryExtensionResponse(c.getId(), c.getName()))
+			.map(category -> new CategoryExtensionResponse(category.getId(), category.getName()))
 			.toList();
 
 		return CategoryAllExtensionResponse.of(recentSaved, response);

--- a/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
@@ -11,7 +11,6 @@ import com.pinback.pinback_server.domain.article.domain.service.ArticleGetServic
 import com.pinback.pinback_server.domain.category.application.command.CategoryCreateCommand;
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForDashboard;
-import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForExtension;
 import com.pinback.pinback_server.domain.category.domain.service.CategoryGetService;
 import com.pinback.pinback_server.domain.category.domain.service.CategorySaveService;
 import com.pinback.pinback_server.domain.category.exception.CategoryAlreadyExistException;
@@ -59,8 +58,8 @@ public class CategoryManagementUsecase {
 			Article article = articleOptional.get();
 			recentSaved = article.getCategory().getName();
 		}
-		CategoriesForExtension projection = categoryGetService.findAllForExtension(user.getId());
-		List<CategoryExtensionResponse> response = projection.getCategories().stream()
+		List<Category> categories = categoryGetService.findAllForExtension(user.getId());
+		List<CategoryExtensionResponse> response = categories.stream()
 			.map(category -> new CategoryExtensionResponse(category.getId(), category.getName()))
 			.toList();
 

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepository.java
@@ -9,7 +9,7 @@ import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
 
 @Repository
-public interface CategoryRepository extends JpaRepository<Category, Long> {
+public interface CategoryRepository extends JpaRepository<Category, Long>, CategoryRepositoryCustom {
 	Optional<Category> findByIdAndUser(long categoryId, User user);
 
 	boolean existsByNameAndUser(String categoryName, User user);

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepositoryCustom.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepositoryCustom.java
@@ -2,8 +2,11 @@ package com.pinback.pinback_server.domain.category.domain.repository;
 
 import java.util.UUID;
 
+import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForDashboard;
 import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForExtension;
 
 public interface CategoryRepositoryCustom {
 	CategoriesForExtension findAllForExtension(UUID userId);
+
+	CategoriesForDashboard findAllForDashboard(UUID userId);
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepositoryCustom.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.pinback.pinback_server.domain.category.domain.repository;
+
+import java.util.UUID;
+
+import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForExtension;
+
+public interface CategoryRepositoryCustom {
+	CategoriesForExtension findAllForExtension(UUID userId);
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepositoryCustom.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepositoryCustom.java
@@ -1,12 +1,13 @@
 package com.pinback.pinback_server.domain.category.domain.repository;
 
+import java.util.List;
 import java.util.UUID;
 
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForDashboard;
-import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForExtension;
 
 public interface CategoryRepositoryCustom {
-	CategoriesForExtension findAllForExtension(UUID userId);
+	List<Category> findAllForExtension(UUID userId);
 
 	CategoriesForDashboard findAllForDashboard(UUID userId);
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepositoryCustomImpl.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.pinback.pinback_server.domain.category.domain.repository;
 
+import static com.pinback.pinback_server.domain.article.domain.entity.QArticle.*;
 import static com.pinback.pinback_server.domain.category.domain.entity.QCategory.*;
 
 import java.util.List;
@@ -8,7 +9,10 @@ import java.util.UUID;
 import org.springframework.stereotype.Repository;
 
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForDashboard;
 import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForExtension;
+import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoryForDashboard;
+import com.pinback.pinback_server.domain.category.domain.repository.dto.QCategoryForDashboard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -28,5 +32,23 @@ public class CategoryRepositoryCustomImpl implements CategoryRepositoryCustom {
 			.fetch();
 
 		return new CategoriesForExtension(categories);
+	}
+
+	@Override
+	public CategoriesForDashboard findAllForDashboard(UUID userId) {
+		List<CategoryForDashboard> categories = queryFactory
+			.select(new QCategoryForDashboard(
+				category.id, category.name, category.id.count().as("unreadCount")))
+			.from(category)
+			.leftJoin(article)
+			.on(article.category.eq(category)
+				.and(article.user.id.eq(userId))
+				.and(article.isRead.isFalse()))
+			.where(category.user.id.eq(userId))
+			.groupBy(category.id, category.name)
+			.orderBy(category.id.asc())
+			.fetch();
+
+		return new CategoriesForDashboard(categories);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepositoryCustomImpl.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepositoryCustomImpl.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Repository;
 
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForDashboard;
-import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForExtension;
 import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoryForDashboard;
 import com.pinback.pinback_server.domain.category.domain.repository.dto.QCategoryForDashboard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -24,14 +23,14 @@ public class CategoryRepositoryCustomImpl implements CategoryRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public CategoriesForExtension findAllForExtension(UUID userId) {
+	public List<Category> findAllForExtension(UUID userId) {
 		List<Category> categories = queryFactory
 			.selectFrom(category)
 			.where(category.user.id.eq(userId))
 			.orderBy(category.id.asc()) // 생성 오래된 순
 			.fetch();
 
-		return new CategoriesForExtension(categories);
+		return categories;
 	}
 
 	@Override

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepositoryCustomImpl.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepositoryCustomImpl.java
@@ -1,0 +1,32 @@
+package com.pinback.pinback_server.domain.category.domain.repository;
+
+import static com.pinback.pinback_server.domain.category.domain.entity.QCategory.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Repository;
+
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForExtension;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CategoryRepositoryCustomImpl implements CategoryRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public CategoriesForExtension findAllForExtension(UUID userId) {
+		List<Category> categories = queryFactory
+			.selectFrom(category)
+			.where(category.user.id.eq(userId))
+			.orderBy(category.id.asc()) // 생성 오래된 순
+			.fetch();
+
+		return new CategoriesForExtension(categories);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepositoryCustomImpl.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/CategoryRepositoryCustomImpl.java
@@ -37,7 +37,7 @@ public class CategoryRepositoryCustomImpl implements CategoryRepositoryCustom {
 	public CategoriesForDashboard findAllForDashboard(UUID userId) {
 		List<CategoryForDashboard> categories = queryFactory
 			.select(new QCategoryForDashboard(
-				category.id, category.name, category.id.count().as("unreadCount")))
+				category.id, category.name, article.id.count().as("unreadCount")))
 			.from(category)
 			.leftJoin(article)
 			.on(article.category.eq(category)

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/dto/CategoriesForDashboard.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/dto/CategoriesForDashboard.java
@@ -1,0 +1,19 @@
+package com.pinback.pinback_server.domain.category.domain.repository.dto;
+
+import java.util.List;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CategoriesForDashboard {
+	private List<CategoryForDashboard> categories;
+
+	@QueryProjection
+	public CategoriesForDashboard(List<CategoryForDashboard> categories) {
+		this.categories = categories;
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/dto/CategoriesForExtension.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/dto/CategoriesForExtension.java
@@ -1,0 +1,20 @@
+package com.pinback.pinback_server.domain.category.domain.repository.dto;
+
+import java.util.List;
+
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CategoriesForExtension {
+	private List<Category> categories;
+
+	@QueryProjection
+	public CategoriesForExtension(List<Category> categories) {
+		this.categories = categories;
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/dto/CategoryForDashboard.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/repository/dto/CategoryForDashboard.java
@@ -1,0 +1,21 @@
+package com.pinback.pinback_server.domain.category.domain.repository.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CategoryForDashboard {
+	private Long id;
+	private String name;
+	private Long unreadCount;
+
+	@QueryProjection
+	public CategoryForDashboard(Long id, String name, Long unreadCount) {
+		this.id = id;
+		this.name = name;
+		this.unreadCount = unreadCount;
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.category.domain.repository.CategoryRepository;
+import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForDashboard;
 import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForExtension;
 import com.pinback.pinback_server.domain.category.exception.CategoryNotFoundException;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
@@ -33,5 +34,9 @@ public class CategoryGetService {
 
 	public CategoriesForExtension findAllForExtension(UUID userId) {
 		return categoryRepository.findAllForExtension(userId);
+	}
+
+	public CategoriesForDashboard findAllForDashboard(UUID userId) {
+		return categoryRepository.findAllForDashboard(userId);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetService.java
@@ -1,10 +1,13 @@
 package com.pinback.pinback_server.domain.category.domain.service;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.category.domain.repository.CategoryRepository;
+import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForExtension;
 import com.pinback.pinback_server.domain.category.exception.CategoryNotFoundException;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
 
@@ -26,5 +29,9 @@ public class CategoryGetService {
 
 	public long countCategoriesByUser(User user) {
 		return categoryRepository.countByUser(user);
+	}
+
+	public CategoriesForExtension findAllForExtension(UUID userId) {
+		return categoryRepository.findAllForExtension(userId);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetService.java
@@ -1,5 +1,6 @@
 package com.pinback.pinback_server.domain.category.domain.service;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -8,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.category.domain.repository.CategoryRepository;
 import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForDashboard;
-import com.pinback.pinback_server.domain.category.domain.repository.dto.CategoriesForExtension;
 import com.pinback.pinback_server.domain.category.exception.CategoryNotFoundException;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
 
@@ -32,7 +32,7 @@ public class CategoryGetService {
 		return categoryRepository.countByUser(user);
 	}
 
-	public CategoriesForExtension findAllForExtension(UUID userId) {
+	public List<Category> findAllForExtension(UUID userId) {
 		return categoryRepository.findAllForExtension(userId);
 	}
 

--- a/src/main/java/com/pinback/pinback_server/domain/category/presentation/CategoryController.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/presentation/CategoryController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.pinback.pinback_server.domain.category.application.CategoryManagementUsecase;
 import com.pinback.pinback_server.domain.category.presentation.dto.request.CategoryCreateRequest;
+import com.pinback.pinback_server.domain.category.presentation.dto.response.CategoryAllDashboardResponse;
 import com.pinback.pinback_server.domain.category.presentation.dto.response.CategoryAllExtensionResponse;
 import com.pinback.pinback_server.domain.category.presentation.dto.response.CreateCategoryResponse;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
@@ -34,6 +35,12 @@ public class CategoryController {
 	@GetMapping("/extension")
 	public ResponseDto<?> getAllExtension(@CurrentUser User user) {
 		CategoryAllExtensionResponse response = categoryManagementUsecase.getAllCategoriesExtension(user);
+		return ResponseDto.ok(response);
+	}
+
+	@GetMapping("/dashboard")
+	public ResponseDto<CategoryAllDashboardResponse> getAllDashboard(@CurrentUser User user) {
+		CategoryAllDashboardResponse response = categoryManagementUsecase.getAllCategoriesDashboard(user);
 		return ResponseDto.ok(response);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/presentation/CategoryController.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/presentation/CategoryController.java
@@ -1,5 +1,6 @@
 package com.pinback.pinback_server.domain.category.presentation;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -7,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.pinback.pinback_server.domain.category.application.CategoryManagementUsecase;
 import com.pinback.pinback_server.domain.category.presentation.dto.request.CategoryCreateRequest;
+import com.pinback.pinback_server.domain.category.presentation.dto.response.CategoryAllExtensionResponse;
 import com.pinback.pinback_server.domain.category.presentation.dto.response.CreateCategoryResponse;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
 import com.pinback.pinback_server.global.common.annotation.CurrentUser;
@@ -27,5 +29,11 @@ public class CategoryController {
 		CreateCategoryResponse response = categoryManagementUsecase.createCategory(user, request.toCommand());
 
 		return ResponseDto.created(response);
+	}
+
+	@GetMapping("/extension")
+	public ResponseDto<?> getAllExtension(@CurrentUser User user) {
+		CategoryAllExtensionResponse response = categoryManagementUsecase.getAllCategoriesExtension(user);
+		return ResponseDto.ok(response);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/presentation/CategoryController.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/presentation/CategoryController.java
@@ -16,7 +16,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/categories")
+@RequestMapping("/api/v1/categories")
 @RequiredArgsConstructor
 public class CategoryController {
 	private final CategoryManagementUsecase categoryManagementUsecase;

--- a/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/CategoryAllDashboardResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/CategoryAllDashboardResponse.java
@@ -1,0 +1,11 @@
+package com.pinback.pinback_server.domain.category.presentation.dto.response;
+
+import java.util.List;
+
+public record CategoryAllDashboardResponse(
+	List<CategoryDashboardResponse> categories
+) {
+	public static CategoryAllDashboardResponse of(List<CategoryDashboardResponse> categories) {
+		return new CategoryAllDashboardResponse(categories);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/CategoryAllExtensionResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/CategoryAllExtensionResponse.java
@@ -1,0 +1,15 @@
+package com.pinback.pinback_server.domain.category.presentation.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CategoryAllExtensionResponse(
+	String recentSaved,
+	List<CategoryExtensionResponse> categories
+) {
+	public static CategoryAllExtensionResponse of(String recentSaved, List<CategoryExtensionResponse> categories) {
+		return new CategoryAllExtensionResponse(recentSaved, categories);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/CategoryDashboardResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/CategoryDashboardResponse.java
@@ -3,6 +3,6 @@ package com.pinback.pinback_server.domain.category.presentation.dto.response;
 public record CategoryDashboardResponse(
 	long categoryId,
 	String categoryName,
-	int unreadCount
+	long unreadCount
 ) {
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/CategoryDashboardResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/CategoryDashboardResponse.java
@@ -1,0 +1,8 @@
+package com.pinback.pinback_server.domain.category.presentation.dto.response;
+
+public record CategoryDashboardResponse(
+	long categoryId,
+	String categoryName,
+	int unreadCount
+) {
+}

--- a/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/CategoryExtensionResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/CategoryExtensionResponse.java
@@ -1,0 +1,7 @@
+package com.pinback.pinback_server.domain.category.presentation.dto.response;
+
+public record CategoryExtensionResponse(
+	long categoryId,
+	String categoryName
+) {
+}


### PR DESCRIPTION
## 🚀 PR 요약

카테고리 이름을 전체 조회하는 기능을 구현합니다.

## ✨ PR 상세 내용

- [x] 익스텐션 카테고리 전체 조회 기능 구현
  - 카테고리는 아티클을 저장할 때 생성됩니다.
  - 최근에 저장한 아티클이 없다면 카테고리도 존재하지 않습니다.
  - 따라서, 최근 저장한 아티클이 없다면, recentSaved는 null(응답 필드에서 제거), categories는 빈 배열로 반환됩니다.

- [x] 대시보드 카테고리 전체 조회 기능 구현
 - 카테고리에 해당하는 아티클 중 읽지 않은 아티클 개수를 반환합니다.

## 🚨 주의 사항

#33 카테고리 대시보드 전체 조회 시 쿼리 개선 예정

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added new API endpoints to fetch category data for extension and dashboard views, including unread counts.
  * Introduced responses showing the most recently saved category alongside full category lists for users.
* **Improvements**
  * Updated the category API base path to `/api/v1/categories` for better versioning and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->