### PR TITLE
feat: 리마인드 아티클 조회 기능 추가

### DIFF
--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepositoryCustom.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepositoryCustom.java
@@ -1,13 +1,18 @@
 package com.pinback.pinback_server.domain.article.domain.repository;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import com.pinback.pinback_server.domain.article.domain.entity.Article;
 import com.pinback.pinback_server.domain.article.domain.repository.dto.ArticlesWithUnreadCount;
 
 public interface ArticleRepositoryCustom {
 	ArticlesWithUnreadCount findAllCustom(UUID userId, Pageable pageable);
 
 	ArticlesWithUnreadCount findAllByCategory(UUID userId, long articleId, Pageable pageable);
+
+	Page<Article> findTodayRemind(UUID userId, Pageable pageable, LocalDateTime startAt, LocalDateTime endAt);
 }

--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/service/ArticleGetService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/service/ArticleGetService.java
@@ -1,8 +1,11 @@
 package com.pinback.pinback_server.domain.article.domain.service;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,5 +38,10 @@ public class ArticleGetService {
 
 	public ArticlesWithUnreadCount findAllByCategory(UUID userId, Category category, PageRequest pageRequest) {
 		return articleRepository.findAllByCategory(userId, category.getId(), pageRequest);
+	}
+
+	public Page<Article> findTodayRemind(UUID userId, LocalDateTime today, Pageable pageable) {
+		LocalDateTime startAt = today.minusDays(1L).plusMinutes(1L);
+		return articleRepository.findTodayRemind(userId, pageable, startAt, today);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/article/presentation/ArticleController.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/presentation/ArticleController.java
@@ -1,5 +1,7 @@
 package com.pinback.pinback_server.domain.article.presentation;
 
+import java.time.LocalDateTime;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,6 +14,7 @@ import com.pinback.pinback_server.domain.article.application.ArticleManagementUs
 import com.pinback.pinback_server.domain.article.presentation.dto.request.ArticleCreateRequest;
 import com.pinback.pinback_server.domain.article.presentation.dto.response.ArticleAllResponse;
 import com.pinback.pinback_server.domain.article.presentation.dto.response.ArticleDetailResponse;
+import com.pinback.pinback_server.domain.article.presentation.dto.response.RemindArticleResponse;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
 import com.pinback.pinback_server.global.common.annotation.CurrentUser;
 import com.pinback.pinback_server.global.common.dto.ResponseDto;
@@ -20,7 +23,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/articles")
+@RequestMapping("api/v1/articles")
 @RequiredArgsConstructor
 public class ArticleController {
 	private final ArticleManagementUsecase articleManagementUsecase;
@@ -51,6 +54,17 @@ public class ArticleController {
 		@RequestParam int pageSize) {
 
 		ArticleAllResponse response = articleManagementUsecase.getAllArticlesByCategory(user, categoryId, pageNumber,
+			pageSize);
+		return ResponseDto.ok(response);
+	}
+
+	@GetMapping("/remind")
+	public ResponseDto<RemindArticleResponse> getAllRemindArticles(@CurrentUser User user,
+		@RequestParam LocalDateTime now,
+		@RequestParam int pageNumber,
+		@RequestParam int pageSize) {
+
+		RemindArticleResponse response = articleManagementUsecase.getRemindArticles(user, now, pageNumber,
 			pageSize);
 		return ResponseDto.ok(response);
 	}

--- a/src/main/java/com/pinback/pinback_server/domain/article/presentation/dto/response/RemindArticleResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/presentation/dto/response/RemindArticleResponse.java
@@ -1,0 +1,11 @@
+package com.pinback.pinback_server.domain.article.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record RemindArticleResponse(
+	long totalArticle,
+	LocalDateTime nextRemind,
+	List<ArticlesResponse> articles
+) {
+}

--- a/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleRemindTest.java
+++ b/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleRemindTest.java
@@ -1,0 +1,63 @@
+package com.pinback.pinback_server.domain.article.application;
+
+import static com.pinback.pinback_server.domain.fixture.TestFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pinback.pinback_server.domain.ApplicationTest;
+import com.pinback.pinback_server.domain.article.domain.repository.ArticleRepository;
+import com.pinback.pinback_server.domain.article.presentation.dto.response.RemindArticleResponse;
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.category.domain.repository.CategoryRepository;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
+import com.pinback.pinback_server.domain.user.domain.repository.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class ArticleRemindTest extends ApplicationTest {
+	@Autowired
+	private ArticleManagementUsecase articleManagementUsecase;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private ArticleRepository articleRepository;
+
+	@DisplayName("오늘 기준을 24시간 이내의 리마인드 아티클 들을 조회한다.")
+	@Test
+	void getByCategoryWithUnreadCount() {
+		//given
+		User user = userRepository.save(user());
+		Category category = categoryRepository.save(category(user));
+
+		//리마인드 시간이 7월 7일 9시 1분, 7월 8일 9시 이라고 가정
+		// 오늘이 7월 8일 9시라고 가정
+		articleRepository.save(
+			articleWithDate(user, "article" + "1", category, LocalDateTime.of(2025, 7, 7, 9, 1, 0)));
+
+		articleRepository.save(
+			articleWithDate(user, "article" + "2", category, LocalDateTime.of(2025, 7, 8, 9, 0, 0)));
+
+		//when
+		RemindArticleResponse responses = articleManagementUsecase.getRemindArticles(user,
+			LocalDateTime.of(2025, 7, 8, 9, 0, 0), 0, 5);
+
+		//then
+		assertThat(responses.totalArticle())
+			.isEqualTo(2);
+
+		assertThat(responses.nextRemind())
+			.isEqualTo(LocalDateTime.of(2025, 7, 9, 12, 0, 0));
+
+	}
+}

--- a/src/test/java/com/pinback/pinback_server/domain/fixture/TestFixture.java
+++ b/src/test/java/com/pinback/pinback_server/domain/fixture/TestFixture.java
@@ -30,6 +30,10 @@ public class TestFixture {
 		return Article.create("test", "testmemo", user, category, LocalDateTime.of(2025, 7, 7, 12, 0, 0));
 	}
 
+	public static Article articleWithDate(User user, String url, Category category, LocalDateTime remindAt) {
+		return Article.create(url, "testmemo", user, category, remindAt);
+	}
+
 	public static Article article(User user, String url, Category category) {
 		return Article.create(url, "testmemo", user, category, LocalDateTime.of(2025, 7, 7, 12, 0, 0));
 	}


### PR DESCRIPTION
## 🚀 PR 요약

close #24 리마인드 아티클을 조회하는 기능을 추가했습니다.

## ✨ PR 상세 내용

1. 현재 날짜에서 24시간 이내 (오늘이 12시라면 전날 12시 1분부터 오늘 12시 까지)의 아티클을 조회합니다.
2. 페이지네이션으로 조회합니다.
3. 최신순으로 조회합니다.

## 🚨 주의 사항

혹시 엣지케이스가 있다면 찾아주세요

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?
