### PR TITLE
fix: 리마인드 조회 응답 수정 및 아티클 생성 글자수 예외 추가

### DIFF
--- a/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
@@ -18,6 +18,7 @@ import com.pinback.pinback_server.domain.article.domain.service.ArticleGetServic
 import com.pinback.pinback_server.domain.article.domain.service.ArticleSaveService;
 import com.pinback.pinback_server.domain.article.exception.ArticleAlreadyExistException;
 import com.pinback.pinback_server.domain.article.exception.ArticleNotOwnedException;
+import com.pinback.pinback_server.domain.article.exception.MemoLengthLimitException;
 import com.pinback.pinback_server.domain.article.presentation.dto.response.ArticleAllResponse;
 import com.pinback.pinback_server.domain.article.presentation.dto.response.ArticleDetailResponse;
 import com.pinback.pinback_server.domain.article.presentation.dto.response.ArticlesResponse;
@@ -39,11 +40,17 @@ public class ArticleManagementUsecase {
 	private final ArticleGetService articleGetService;
 	private final ArticleDeleteService articleDeleteService;
 
+	private final long MEMO_LIMIT_LENGTH = 1000;
+
 	//TODO: 리마인드 로직 추가 필요
 	@Transactional
 	public void createArticle(User user, ArticleCreateCommand command) {
 		if (articleGetService.checkExistsByUserAndUrl(user, command.url())) {
 			throw new ArticleAlreadyExistException();
+		}
+
+		if (command.memo().length() >= MEMO_LIMIT_LENGTH) {
+			throw new MemoLengthLimitException();
 		}
 		Category category = categoryGetService.getCategoryAndUser(command.categoryId(), user);
 		Article article = Article.create(command.url(), command.memo(), user, category, command.remindTime());

--- a/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
@@ -1,6 +1,7 @@
 package com.pinback.pinback_server.domain.article.application;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 
@@ -102,7 +103,7 @@ public class ArticleManagementUsecase {
 
 		return new RemindArticleResponse(
 			articles.getTotalElements(),
-			remindDateTime,
+			remindDateTime.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 a HH시 mm분")),
 			articlesResponses
 		);
 	}

--- a/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
@@ -3,6 +3,7 @@ package com.pinback.pinback_server.domain.article.application;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -110,7 +111,7 @@ public class ArticleManagementUsecase {
 
 		return new RemindArticleResponse(
 			articles.getTotalElements(),
-			remindDateTime.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 a HH시 mm분")),
+			remindDateTime.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 a HH시 mm분", Locale.KOREAN)),
 			articlesResponses
 		);
 	}

--- a/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
@@ -28,6 +28,7 @@ import com.pinback.pinback_server.domain.article.presentation.dto.response.Remin
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.category.domain.service.CategoryGetService;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
+import com.pinback.pinback_server.global.common.util.TextUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -50,7 +51,7 @@ public class ArticleManagementUsecase {
 			throw new ArticleAlreadyExistException();
 		}
 
-		if (command.memo().length() >= MEMO_LIMIT_LENGTH) {
+		if (TextUtil.countGraphemeClusters(command.memo()) >= MEMO_LIMIT_LENGTH) {
 			throw new MemoLengthLimitException();
 		}
 		Category category = categoryGetService.getCategoryAndUser(command.categoryId(), user);

--- a/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
@@ -21,6 +21,7 @@ import com.pinback.pinback_server.domain.article.presentation.dto.response.Artic
 import com.pinback.pinback_server.domain.article.presentation.dto.response.ArticleDetailResponse;
 import com.pinback.pinback_server.domain.article.presentation.dto.response.ArticlesResponse;
 import com.pinback.pinback_server.domain.article.presentation.dto.response.RemindArticleResponse;
+import com.pinback.pinback_server.domain.article.presentation.dto.response.RemindArticles;
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.category.domain.service.CategoryGetService;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
@@ -95,8 +96,8 @@ public class ArticleManagementUsecase {
 		Page<Article> articles = articleGetService.findTodayRemind(user.getId(), now,
 			PageRequest.of(pageNumber, pageSize));
 
-		List<ArticlesResponse> articlesResponses = articles.stream()
-			.map(ArticlesResponse::from)
+		List<RemindArticles> articlesResponses = articles.stream()
+			.map(RemindArticles::from)
 			.toList();
 
 		return new RemindArticleResponse(

--- a/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
@@ -37,12 +37,12 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class ArticleManagementUsecase {
 
+	private static final long MEMO_LIMIT_LENGTH = 1000;
+	
 	private final CategoryGetService categoryGetService;
 	private final ArticleSaveService articleSaveService;
 	private final ArticleGetService articleGetService;
 	private final ArticleDeleteService articleDeleteService;
-
-	private final long MEMO_LIMIT_LENGTH = 1000;
 
 	//TODO: 리마인드 로직 추가 필요
 	@Transactional

--- a/src/main/java/com/pinback/pinback_server/domain/article/exception/MemoLengthLimitException.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/exception/MemoLengthLimitException.java
@@ -1,0 +1,10 @@
+package com.pinback.pinback_server.domain.article.exception;
+
+import com.pinback.pinback_server.global.exception.ApplicationException;
+import com.pinback.pinback_server.global.exception.constant.ExceptionCode;
+
+public class MemoLengthLimitException extends ApplicationException {
+	public MemoLengthLimitException() {
+		super(ExceptionCode.TEXT_LENGTH_OVER);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/article/presentation/dto/response/RemindArticleResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/presentation/dto/response/RemindArticleResponse.java
@@ -1,11 +1,10 @@
 package com.pinback.pinback_server.domain.article.presentation.dto.response;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 public record RemindArticleResponse(
 	long totalArticle,
-	LocalDateTime nextRemind,
+	String nextRemind,
 	List<RemindArticles> articles
 ) {
 }

--- a/src/main/java/com/pinback/pinback_server/domain/article/presentation/dto/response/RemindArticleResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/presentation/dto/response/RemindArticleResponse.java
@@ -6,6 +6,6 @@ import java.util.List;
 public record RemindArticleResponse(
 	long totalArticle,
 	LocalDateTime nextRemind,
-	List<ArticlesResponse> articles
+	List<RemindArticles> articles
 ) {
 }

--- a/src/main/java/com/pinback/pinback_server/domain/article/presentation/dto/response/RemindArticles.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/presentation/dto/response/RemindArticles.java
@@ -1,0 +1,23 @@
+package com.pinback.pinback_server.domain.article.presentation.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.pinback.pinback_server.domain.article.domain.entity.Article;
+
+public record RemindArticles(
+	long articleId,
+	String url,
+	String memo,
+	LocalDateTime remindAt,
+	boolean isRead
+) {
+	public static RemindArticles from(Article article) {
+		return new RemindArticles(
+			article.getId(),
+			article.getUrl(),
+			article.getMemo(),
+			article.getRemindAt(),
+			article.isRead()
+		);
+	}
+}

--- a/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleRemindTest.java
+++ b/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleRemindTest.java
@@ -57,7 +57,7 @@ public class ArticleRemindTest extends ApplicationTest {
 			.isEqualTo(2);
 
 		assertThat(responses.nextRemind())
-			.isEqualTo(LocalDateTime.of(2025, 7, 9, 12, 0, 0));
+			.isEqualTo("2025년 07월 09일 오후 12시 00분");
 
 		assertThat(responses.articles().get(1).remindAt()).isEqualTo(LocalDateTime.of(2025, 7, 7, 9, 1, 0));
 
@@ -101,7 +101,8 @@ public class ArticleRemindTest extends ApplicationTest {
 
 		//then
 		assertThat(responses.nextRemind())
-			.isEqualTo(LocalDateTime.of(2025, 8, 1, 12, 0, 0));
+			.isEqualTo("2025년 08월 01일 오후 12시 00분");
+		//2025년 8월 1일 오후 12시 00분
 
 	}
 }

--- a/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleRemindTest.java
+++ b/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleRemindTest.java
@@ -59,6 +59,8 @@ public class ArticleRemindTest extends ApplicationTest {
 		assertThat(responses.nextRemind())
 			.isEqualTo(LocalDateTime.of(2025, 7, 9, 12, 0, 0));
 
+		assertThat(responses.articles().get(1).remindAt()).isEqualTo(LocalDateTime.of(2025, 7, 7, 9, 1, 0));
+
 	}
 
 	@DisplayName("오늘 기준을 24시간 범위 외의 아티클들을 조회할 수 없다.")


### PR DESCRIPTION
## 🚀 PR 요약

리마인드 조회 응답을 수정하고 아티클 생성 글자수에 예외를 추가했습니다.

close #43 
close #41 

## ✨ PR 상세 내용

1. 리마인드 조회시 생성일자 대신 리마인드 시간을 보내주도록 변경했습니다.
2. 리마인드 시간 포맷을 24시간에서 오전/오후 형태로 변경했습니다.
3. 아티클 생성시 글자수 1000자를 넘어갈 경우 예외를 던지도록 변경했습니다.

## 🚨 주의 사항

없습니다. 

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a limit to memo length when creating articles, with an error shown if the limit is exceeded.
  * Introduced a new error message for memos that are too long.

* **Improvements**
  * Remind article response now displays the next reminder date and time as a formatted string.
  * Enhanced the structure of remind article responses for clearer information.

* **Bug Fixes**
  * Updated tests to verify new date formatting and memo length validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->