### PR TITLE
feat: 아티클 읽음 표시 변경 기능 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - ./redis/redis.conf:/usr/local/etc/redis/redis.conf
     environment:
       REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      TZ: Asia/Seoul
     command: redis-server /usr/local/etc/redis/redis.conf --requirepass ${REDIS_PASSWORD:-}
     restart: always # 컨테이너 비정상 종료 또는 호스트 재부팅 시 자동 재시작
 
@@ -21,6 +22,7 @@ services:
     depends_on:
       - redis
     environment:
+      TZ: Asia/Seoul
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_PASSWORD: ${REDIS_PASSWORD:-}

--- a/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
@@ -23,26 +23,32 @@ import com.pinback.pinback_server.domain.article.exception.MemoLengthLimitExcept
 import com.pinback.pinback_server.domain.article.presentation.dto.response.ArticleAllResponse;
 import com.pinback.pinback_server.domain.article.presentation.dto.response.ArticleDetailResponse;
 import com.pinback.pinback_server.domain.article.presentation.dto.response.ArticlesResponse;
+import com.pinback.pinback_server.domain.article.presentation.dto.response.ReadArticleResponse;
 import com.pinback.pinback_server.domain.article.presentation.dto.response.RemindArticleResponse;
 import com.pinback.pinback_server.domain.article.presentation.dto.response.RemindArticles;
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.category.domain.service.CategoryGetService;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
 import com.pinback.pinback_server.global.common.util.TextUtil;
+import com.pinback.pinback_server.infra.redis.AcornService;
+import com.pinback.pinback_server.infra.redis.dto.response.AcornCollectResponse;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ArticleManagementUsecase {
 
 	private static final long MEMO_LIMIT_LENGTH = 1000;
-	
+
 	private final CategoryGetService categoryGetService;
 	private final ArticleSaveService articleSaveService;
 	private final ArticleGetService articleGetService;
 	private final ArticleDeleteService articleDeleteService;
+	private final AcornService acornService;
 
 	//TODO: 리마인드 로직 추가 필요
 	@Transactional
@@ -115,6 +121,26 @@ public class ArticleManagementUsecase {
 			remindDateTime.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 a HH시 mm분", Locale.KOREAN)),
 			articlesResponses
 		);
+	}
+
+	@Transactional
+	public ReadArticleResponse updateStatusArticle(User user, long articleId) {
+		Article article = articleGetService.findByUserAndId(user, articleId);
+
+		// acornService.resetAcornsForTest(user.getId()); //테스트용 redis 키 삭제 메서드
+		int finalAcornCount = acornService.getCurrentAcorns(user.getId());
+		log.info("수집하기 전 도토리 수: {}", finalAcornCount);
+		boolean acornCollected = false; // 해당 요청으로 도토리가 수집되었는지 여부
+
+		if (!article.isRead()) {
+			article.toRead();
+
+			AcornCollectResponse response = acornService.tryCollectAcorns(user);
+			finalAcornCount = response.finalAcornCount();
+			acornCollected = response.isCollected();
+
+		}
+		return ReadArticleResponse.of(finalAcornCount, acornCollected);
 	}
 
 	public ArticleDetailResponse checkArticleExists(User user, String url) {

--- a/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
@@ -124,7 +124,7 @@ public class ArticleManagementUsecase {
 	}
 
 	@Transactional
-	public ReadArticleResponse updateStatusArticle(User user, long articleId) {
+	public ReadArticleResponse updateArticleStatus(User user, long articleId) {
 		Article article = articleGetService.findByUserAndId(user, articleId);
 
 		// acornService.resetAcornsForTest(user.getId()); //테스트용 redis 키 삭제 메서드

--- a/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecase.java
@@ -138,6 +138,7 @@ public class ArticleManagementUsecase {
 			AcornCollectResponse response = acornService.tryCollectAcorns(user);
 			finalAcornCount = response.finalAcornCount();
 			acornCollected = response.isCollected();
+			return ReadArticleResponse.of(finalAcornCount, acornCollected);
 
 		}
 		return ReadArticleResponse.of(finalAcornCount, acornCollected);

--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepository.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepository.java
@@ -19,4 +19,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Article
 	Optional<Article> findRecentArticleByUser(@Param("user") User user);
 
 	Optional<Article> findArticleByUserAndUrl(User user, String url);
+
+	Optional<Article> findArticleByUserAndId(User user, Long id);
 }

--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/service/ArticleGetService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/service/ArticleGetService.java
@@ -54,4 +54,8 @@ public class ArticleGetService {
 	public Optional<Article> findByUrlAndUser(User user, String url) {
 		return articleRepository.findArticleByUserAndUrl(user, url);
 	}
+
+	public Article findByUserAndId(User user, long articleId) {
+		return articleRepository.findArticleByUserAndId(user, articleId).orElseThrow(ArticleNotFoundException::new);
+	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/article/presentation/ArticleController.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/presentation/ArticleController.java
@@ -94,7 +94,7 @@ public class ArticleController {
 		@CurrentUser User user,
 		@PathVariable Long articleId
 	) {
-		ReadArticleResponse response = articleManagementUsecase.updateStatusArticle(user, articleId);
+		ReadArticleResponse response = articleManagementUsecase.updateArticleStatus(user, articleId);
 		return ResponseDto.ok(response);
 	}
 

--- a/src/main/java/com/pinback/pinback_server/domain/article/presentation/ArticleController.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/presentation/ArticleController.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +16,7 @@ import com.pinback.pinback_server.domain.article.application.ArticleManagementUs
 import com.pinback.pinback_server.domain.article.presentation.dto.request.ArticleCreateRequest;
 import com.pinback.pinback_server.domain.article.presentation.dto.response.ArticleAllResponse;
 import com.pinback.pinback_server.domain.article.presentation.dto.response.ArticleDetailResponse;
+import com.pinback.pinback_server.domain.article.presentation.dto.response.ReadArticleResponse;
 import com.pinback.pinback_server.domain.article.presentation.dto.response.RemindArticleResponse;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
 import com.pinback.pinback_server.global.common.annotation.CurrentUser;
@@ -84,6 +86,15 @@ public class ArticleController {
 		@RequestParam String url) {
 
 		ArticleDetailResponse response = articleManagementUsecase.checkArticleExists(user, url);
+		return ResponseDto.ok(response);
+	}
+
+	@PatchMapping("{articleId}/readStatus")
+	public ResponseDto<?> updateArticleReadStatus(
+		@CurrentUser User user,
+		@PathVariable Long articleId
+	) {
+		ReadArticleResponse response = articleManagementUsecase.updateStatusArticle(user, articleId);
 		return ResponseDto.ok(response);
 	}
 

--- a/src/main/java/com/pinback/pinback_server/domain/article/presentation/dto/response/ReadArticleResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/presentation/dto/response/ReadArticleResponse.java
@@ -1,0 +1,11 @@
+package com.pinback.pinback_server.domain.article.presentation.dto.response;
+
+public record ReadArticleResponse(
+	int finalAcornCount,
+	boolean isCollected
+) {
+
+	public static ReadArticleResponse of(int finalAcornCount, boolean isCollected) {
+		return new ReadArticleResponse(finalAcornCount, isCollected);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/infra/redis/AcornService.java
+++ b/src/main/java/com/pinback/pinback_server/infra/redis/AcornService.java
@@ -40,22 +40,22 @@ public class AcornService {
 		String key = REDIS_KEY_PREFIX + user.getId();
 		int currentAcorns = getCurrentAcorns(user.getId());
 		int finalAcorns;
-		boolean isCollected;
 
 		if (currentAcorns < MAX_ACORNS_PER_DAY) {
 			finalAcorns = currentAcorns + 1;
 			long ttlSeconds = calculateTtlSeconds(user);
 			redisTemplate.opsForValue().set(key, String.valueOf(finalAcorns), ttlSeconds, TimeUnit.SECONDS);
-			isCollected = true;
 			log.info("사용자 {}가 도토리 1개를 획득했습니다. 최종 도토리: {}, TTL: {} 초", user.getId(), finalAcorns, ttlSeconds);
-		} else {
-			finalAcorns = currentAcorns;
-			isCollected = false;
-			log.info("사용자 {}는 일일 도토리 한도({})에 도달하였습니다. 최종 도토리: {}", user.getId(), MAX_ACORNS_PER_DAY, finalAcorns);
+			return AcornCollectResponse.builder()
+				.finalAcornCount(finalAcorns)
+				.isCollected(true)
+				.build();
 		}
+		finalAcorns = currentAcorns;
+		log.info("사용자 {}는 일일 도토리 한도({})에 도달하였습니다. 최종 도토리: {}", user.getId(), MAX_ACORNS_PER_DAY, finalAcorns);
 		return AcornCollectResponse.builder()
 			.finalAcornCount(finalAcorns)
-			.isCollected(isCollected)
+			.isCollected(false)
 			.build();
 	}
 

--- a/src/main/java/com/pinback/pinback_server/infra/redis/AcornService.java
+++ b/src/main/java/com/pinback/pinback_server/infra/redis/AcornService.java
@@ -1,0 +1,89 @@
+package com.pinback.pinback_server.infra.redis;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.pinback.pinback_server.domain.user.domain.entity.User;
+import com.pinback.pinback_server.infra.redis.dto.response.AcornCollectResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AcornService {
+
+	private static final long MAX_ACORNS_PER_DAY = 7;
+	private static final String REDIS_KEY_PREFIX = "daily_acorns:";
+	private static final ZoneId SEOUL_ZONE_ID = ZoneId.of("Asia/Seoul");
+	private final StringRedisTemplate redisTemplate;
+
+	public int getCurrentAcorns(UUID userId) {
+		String key = REDIS_KEY_PREFIX + userId.toString();
+		String acornsStr = redisTemplate.opsForValue().get(key);
+
+		return Optional.ofNullable(acornsStr)
+			.map(Integer::parseInt) // String -> int 변환
+			.orElse(0); // null -> 0 반환
+	}
+
+	public AcornCollectResponse tryCollectAcorns(User user) {
+		String key = REDIS_KEY_PREFIX + user.getId();
+		int currentAcorns = getCurrentAcorns(user.getId());
+		int finalAcorns;
+		boolean isCollected;
+
+		if (currentAcorns < MAX_ACORNS_PER_DAY) {
+			finalAcorns = currentAcorns + 1;
+			long ttlSeconds = calculateTtlSeconds(user);
+			redisTemplate.opsForValue().set(key, String.valueOf(finalAcorns), ttlSeconds, TimeUnit.SECONDS);
+			isCollected = true;
+			log.info("사용자 {}가 도토리 1개를 획득했습니다. 최종 도토리: {}, TTL: {} 초", user.getId(), finalAcorns, ttlSeconds);
+		} else {
+			finalAcorns = currentAcorns;
+			isCollected = false;
+			log.info("사용자 {}는 일일 도토리 한도({})에 도달하였습니다. 최종 도토리: {}", user.getId(), MAX_ACORNS_PER_DAY, finalAcorns);
+		}
+		return AcornCollectResponse.builder()
+			.finalAcornCount(finalAcorns)
+			.isCollected(isCollected)
+			.build();
+	}
+
+	public void resetAcornsForTest(UUID userId) {
+		String key = REDIS_KEY_PREFIX + userId.toString();
+		Boolean deleted = redisTemplate.delete(key);
+
+		if (deleted != null && deleted) {
+			log.info("TEST_RESET: 사용자 {}의 도토리 개수를 0으로 초기화했습니다 (Redis 키 '{}' 삭제됨).", userId, key);
+		} else {
+			log.warn("TEST_RESET: 사용자 {}의 도토리 개수 초기화 시도했으나, Redis 키 '{}'를 찾을 수 없거나 삭제되지 않았습니다.", userId, key);
+		}
+	}
+
+	private long calculateTtlSeconds(User user) {
+		LocalTime reminderTime = user.getRemindDefault();
+
+		LocalDateTime now = LocalDateTime.now(SEOUL_ZONE_ID);
+		LocalDateTime nextReminderDateTime;
+
+		if (now.toLocalTime().isBefore(reminderTime)) {
+			nextReminderDateTime = now.with(reminderTime);
+		} else {
+			nextReminderDateTime = now.plusDays(1).with(reminderTime);
+		}
+
+		long ttl = Duration.between(now, nextReminderDateTime).getSeconds();
+		log.info("ttl : {}", ttl);
+		return Math.max(1, ttl);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/infra/redis/dto/response/AcornCollectResponse.java
+++ b/src/main/java/com/pinback/pinback_server/infra/redis/dto/response/AcornCollectResponse.java
@@ -1,0 +1,10 @@
+package com.pinback.pinback_server.infra.redis.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AcornCollectResponse(
+	int finalAcornCount,
+	boolean isCollected
+) {
+}


### PR DESCRIPTION
## 🚀 PR 요약
#50 
아티클 읽음 표시 변경 기능을 구현합니다.

## ✨ PR 상세 내용
- 요구사항
  - 도토리는 24시간동안 최대 7개까지 모을 수 있습니다.
  - 아티클의 읽음 상태(isRead)가 true로 변경될 때 도토리 개수가 1개씩 증가합니다.
  - 도토리 개수가 초기화되는 시점은 다음날 자신이 설정한 리마인드 시각입니다.

- 구현 방법
  1. 사용자가 읽음 조건을 충족할 경우 읽음 표시 변경 API 요청
  2. redis의 key(userId)를 통해 도토리 조회
    - null 이면 0을 반환
  3. 도토리 수가 6이하(0~6)인 경우 현재 도토리수의 +1을, 7 이상인 경우 조회한 도토리 수 반환

- 응답값으로 finalAcornCount(도토리 개수)와 isCollected(해당 요청으로 인한 도토리 개수 증가 여부) 값을 반환합니다.

## 🚨 주의 사항


## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a PATCH endpoint to update the read status of an article.
  * Users now receive acorns when marking an article as read, with daily limits managed automatically.
  * Users can view whether acorns were collected and their current acorn count after updating an article's read status.

* **Backend Services**
  * Introduced a new service to manage daily acorn collection and reset counts based on user-specific reminder times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->