### PR TITLE
feat: 유저 기본 리마인드 시간 조회 기능 구현

### DIFF
--- a/src/main/java/com/pinback/pinback_server/domain/user/application/UserManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/user/application/UserManagementUsecase.java
@@ -1,5 +1,6 @@
 package com.pinback.pinback_server.domain.user.application;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -11,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
 import com.pinback.pinback_server.domain.user.domain.service.UserGetService;
 import com.pinback.pinback_server.domain.user.presentation.dto.response.UserInfoResponse;
+import com.pinback.pinback_server.domain.user.presentation.dto.response.UserRemindInfoResponse;
 import com.pinback.pinback_server.infra.redis.AcornService;
 
 import lombok.RequiredArgsConstructor;
@@ -34,6 +36,15 @@ public class UserManagementUsecase {
 		int finalAcornCount = acornService.getCurrentAcorns(getUser.getId());
 
 		return UserInfoResponse.of(finalAcornCount, formattedRemindTime);
+	}
+
+	@Transactional(readOnly = true)
+	public UserRemindInfoResponse getUserRemindInfo(User user, LocalDateTime now) {
+		User getUser = userGetService.getUser(user.getId());
+		LocalTime userRemindTime = getUser.getRemindDefault();
+		LocalDate userRemindDate = now.toLocalDate().plusDays(1L);
+
+		return UserRemindInfoResponse.of(userRemindDate, userRemindTime);
 	}
 
 	private String formatRemindDateTime(LocalDateTime remindDateTime) {

--- a/src/main/java/com/pinback/pinback_server/domain/user/presentation/UserController.java
+++ b/src/main/java/com/pinback/pinback_server/domain/user/presentation/UserController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.pinback.pinback_server.domain.user.application.UserManagementUsecase;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
 import com.pinback.pinback_server.domain.user.presentation.dto.response.UserInfoResponse;
+import com.pinback.pinback_server.domain.user.presentation.dto.response.UserRemindInfoResponse;
 import com.pinback.pinback_server.global.common.annotation.CurrentUser;
 import com.pinback.pinback_server.global.common.dto.ResponseDto;
 
@@ -28,5 +29,14 @@ public class UserController {
 	) {
 		UserInfoResponse userInfoResponse = userManagementUsecase.getUserInfo(user, now);
 		return ResponseDto.ok(userInfoResponse);
+	}
+
+	@GetMapping("/remind-time")
+	public ResponseDto<UserRemindInfoResponse> getRemindInfo(
+		@CurrentUser User user,
+		@RequestParam LocalDateTime now
+	) {
+		UserRemindInfoResponse response = userManagementUsecase.getUserRemindInfo(user, now);
+		return ResponseDto.ok(response);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/user/presentation/dto/response/UserRemindInfoResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/user/presentation/dto/response/UserRemindInfoResponse.java
@@ -1,0 +1,13 @@
+package com.pinback.pinback_server.domain.user.presentation.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record UserRemindInfoResponse(
+	LocalDate remindDate,
+	LocalTime remindDateTime
+) {
+	public static UserRemindInfoResponse of(LocalDate remindDate, LocalTime remindDateTime) {
+		return new UserRemindInfoResponse(remindDate, remindDateTime);
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/user/presentation/dto/response/UserRemindInfoResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/user/presentation/dto/response/UserRemindInfoResponse.java
@@ -5,9 +5,9 @@ import java.time.LocalTime;
 
 public record UserRemindInfoResponse(
 	LocalDate remindDate,
-	LocalTime remindDateTime
+	LocalTime remindTime
 ) {
-	public static UserRemindInfoResponse of(LocalDate remindDate, LocalTime remindDateTime) {
-		return new UserRemindInfoResponse(remindDate, remindDateTime);
+	public static UserRemindInfoResponse of(LocalDate remindDate, LocalTime remindTime) {
+		return new UserRemindInfoResponse(remindDate, remindTime);
 	}
 }


### PR DESCRIPTION
## 🚀 PR 요약

익스텐션에서 아티클 생성 및 수정 시 보여지는 유저의 기본 리마인드 시간을 조회하는 기능을 구현합니다.

## ✨ PR 상세 내용

- [x] 유저 기본 리마인드 시간 조회 기능 구현

## 🚨 주의 사항

없습니다.

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve a user's reminder date and time based on the current timestamp.
  * Users can now view their next scheduled reminder information through the new endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->