### PR TITLE
fix: 리마인드 아티클 조회시 조회조건 변경

### DIFF
--- a/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecaseTest.java
+++ b/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleManagementUsecaseTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.pinback.pinback_server.domain.ApplicationTest;
@@ -39,6 +40,8 @@ class ArticleManagementUsecaseTest extends ApplicationTest {
 	private CategoryRepository categoryRepository;
 	@Autowired
 	private ArticleRepository articleRepository;
+	@MockitoBean
+	private org.springframework.data.redis.listener.RedisMessageListenerContainer RedisMessageListenerContainer;
 
 	//TODO: 나중에 firebase mocking 처리해서 주석 해제 할 것
 

--- a/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleRemindTest.java
+++ b/src/test/java/com/pinback/pinback_server/domain/article/application/ArticleRemindTest.java
@@ -9,7 +9,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.pinback.pinback_server.domain.ApplicationTest;
@@ -32,25 +34,25 @@ public class ArticleRemindTest extends ApplicationTest {
 	private CategoryRepository categoryRepository;
 	@Autowired
 	private ArticleRepository articleRepository;
+	@MockitoBean
+	private RedisMessageListenerContainer RedisMessageListenerContainer;
 
-	@DisplayName("오늘 기준을 24시간 이내의 리마인드 아티클 들을 조회한다.")
+	@DisplayName("오늘 리마인드 시간에서 부터 24시간 이내의 리마인드 아티클들을 조회한다.")
 	@Test
 	void getRemindArticleInRange() {
 		//given
 		User user = userRepository.save(user());
 		Category category = categoryRepository.save(category(user));
 
-		//리마인드 시간이 7월 7일 9시 1분, 7월 8일 9시 이라고 가정
-		// 오늘이 7월 8일 9시라고 가정
 		articleRepository.save(
-			articleWithDate(user, "article" + "1", category, LocalDateTime.of(2025, 7, 7, 9, 1, 0)));
+			articleWithDate(user, "article" + "1", category, LocalDateTime.of(2025, 7, 7, 12, 1, 0)));
 
 		articleRepository.save(
-			articleWithDate(user, "article" + "2", category, LocalDateTime.of(2025, 7, 8, 9, 0, 0)));
+			articleWithDate(user, "article" + "2", category, LocalDateTime.of(2025, 7, 8, 12, 0, 0)));
 
 		//when
 		RemindArticleResponse responses = articleManagementUsecase.getRemindArticles(user,
-			LocalDateTime.of(2025, 7, 8, 9, 0, 0), 0, 5);
+			LocalDateTime.of(2025, 7, 8, 17, 0, 0), 0, 5);
 
 		//then
 		assertThat(responses.totalArticle())
@@ -59,7 +61,7 @@ public class ArticleRemindTest extends ApplicationTest {
 		assertThat(responses.nextRemind())
 			.isEqualTo("2025년 07월 09일 오후 12시 00분");
 
-		assertThat(responses.articles().get(1).remindAt()).isEqualTo(LocalDateTime.of(2025, 7, 7, 9, 1, 0));
+		assertThat(responses.articles().get(1).remindAt()).isEqualTo(LocalDateTime.of(2025, 7, 7, 12, 1, 0));
 
 	}
 
@@ -76,7 +78,10 @@ public class ArticleRemindTest extends ApplicationTest {
 			articleWithDate(user, "article" + "1", category, LocalDateTime.of(2025, 7, 7, 9, 0, 0)));
 
 		articleRepository.save(
-			articleWithDate(user, "article" + "2", category, LocalDateTime.of(2025, 7, 8, 9, 1, 0)));
+			articleWithDate(user, "article" + "2", category, LocalDateTime.of(2025, 7, 8, 12, 1, 0)));
+
+		articleRepository.save(
+			articleWithDate(user, "article" + "3", category, LocalDateTime.of(2025, 7, 8, 15, 0, 0)));
 
 		//when
 		RemindArticleResponse responses = articleManagementUsecase.getRemindArticles(user,

--- a/src/test/java/com/pinback/pinback_server/domain/auth/application/AuthUsecaseTest.java
+++ b/src/test/java/com/pinback/pinback_server/domain/auth/application/AuthUsecaseTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.pinback.pinback_server.domain.auth.application.command.SignUpCommand;
@@ -31,6 +32,9 @@ class AuthUsecaseTest {
 
 	@Autowired
 	private JwtUtil jwtUtil;
+	
+	@MockitoBean
+	private org.springframework.data.redis.listener.RedisMessageListenerContainer RedisMessageListenerContainer;
 
 	@DisplayName("사용자는 회원가입을 할 수 있다.")
 	@Test

--- a/src/test/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetServiceTest.java
+++ b/src/test/java/com/pinback/pinback_server/domain/category/domain/service/CategoryGetServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
@@ -28,6 +29,9 @@ class CategoryGetServiceTest {
 
 	@Autowired
 	private CategoryGetService categoryGetService;
+
+	@MockitoBean
+	private org.springframework.data.redis.listener.RedisMessageListenerContainer RedisMessageListenerContainer;
 
 	@DisplayName("카테고리 소유자가 아닐경우 예외가 발생한다.")
 	@Test

--- a/src/test/java/com/pinback/pinback_server/global/common/jwt/JwtProviderTest.java
+++ b/src/test/java/com/pinback/pinback_server/global/common/jwt/JwtProviderTest.java
@@ -9,12 +9,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @ActiveProfiles("test")
 class JwtProviderTest {
 	@Autowired
 	private JwtProvider jwtProvider;
+	@MockitoBean
+	private org.springframework.data.redis.listener.RedisMessageListenerContainer RedisMessageListenerContainer;
 
 	@DisplayName("jwt 토큰을 생성할 수 있다.")
 	@Test

--- a/src/test/java/com/pinback/pinback_server/global/common/jwt/JwtUtilTest.java
+++ b/src/test/java/com/pinback/pinback_server/global/common/jwt/JwtUtilTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -21,6 +22,9 @@ class JwtUtilTest {
 
 	@Autowired
 	private JwtProvider jwtProvider;
+
+	@MockitoBean
+	private org.springframework.data.redis.listener.RedisMessageListenerContainer RedisMessageListenerContainer;
 
 	@DisplayName("토큰에서 올바르게 유저 ID를 추출한다.")
 	@Test


### PR DESCRIPTION
## 🚀 PR 요약

리마인드 아티클 조회시 조회조건을 변경합니다.

## ✨ PR 상세 내용

1. 현재시점에서 24시간 동안의 리마인드 아티클이 아닌 온보딩시 설정한 기본 리마인드 시간 기준 24시간동안의 아티클을 조회합니다.

## 🚨 주의 사항

테스트 안터지게 redis 관련 mock bean 처리했습니다.

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?
