### PR TITLE
feat: 유저 도토리 조회 시 리마인드 시간 타입 변경

### DIFF
--- a/src/main/java/com/pinback/pinback_server/domain/user/application/UserManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/user/application/UserManagementUsecase.java
@@ -3,8 +3,6 @@ package com.pinback.pinback_server.domain.user.application;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Locale;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,11 +42,6 @@ public class UserManagementUsecase {
 		LocalDate userRemindDate = now.toLocalDate().plusDays(1L);
 
 		return UserRemindInfoResponse.of(userRemindDate, userRemindTime);
-	}
-
-	private String formatRemindDateTime(LocalDateTime remindDateTime) {
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 a HH시 mm분", Locale.KOREAN);
-		return remindDateTime.format(formatter);
 	}
 
 	private LocalDateTime getRemindDateTime(LocalDateTime now, LocalTime remindDefault) {

--- a/src/main/java/com/pinback/pinback_server/domain/user/application/UserManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/user/application/UserManagementUsecase.java
@@ -31,11 +31,10 @@ public class UserManagementUsecase {
 
 		LocalTime userRemindDefault = getUser.getRemindDefault();
 		LocalDateTime remindDateTime = getRemindDateTime(now, userRemindDefault);
-		String formattedRemindTime = formatRemindDateTime(remindDateTime);
 
 		int finalAcornCount = acornService.getCurrentAcorns(getUser.getId());
 
-		return UserInfoResponse.of(finalAcornCount, formattedRemindTime);
+		return UserInfoResponse.of(finalAcornCount, remindDateTime);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/pinback/pinback_server/domain/user/presentation/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/user/presentation/dto/response/UserInfoResponse.java
@@ -1,10 +1,12 @@
 package com.pinback.pinback_server.domain.user.presentation.dto.response;
 
+import java.time.LocalDateTime;
+
 public record UserInfoResponse(
 	int acornCount,
-	String remindDateTime
+	LocalDateTime remindDateTime
 ) {
-	public static UserInfoResponse of(int acornCount, String remindDateTime) {
+	public static UserInfoResponse of(int acornCount, LocalDateTime remindDateTime) {
 		return new UserInfoResponse(acornCount, remindDateTime);
 	}
 }


### PR DESCRIPTION
## 🚀 PR 요약

대시보드에서 유저 도토리 조회 시 반환하는 리마인드 시간 remindDateTime의 타입을 String에서 LocalDateTime으로 변경합니다.

## ✨ PR 상세 내용

- [x] 리마인드 시간 remindDateTime의 타입을 String에서 LocalDateTime으로 변경

## 🚨 주의 사항

주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The reminder date and time in user information is now provided as a date-time object instead of a formatted string, allowing for more precise handling and display in client applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->