### PR TITLE
refactor: 카테고리 생성/수정 응답 DTO 필드명 변경

### DIFF
--- a/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/CreateCategoryResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/CreateCategoryResponse.java
@@ -1,10 +1,10 @@
 package com.pinback.pinback_server.domain.category.presentation.dto.response;
 
 public record CreateCategoryResponse(
-	long id,
+	long categoryId,
 	String categoryName
 ) {
-	public static CreateCategoryResponse of(long id, String categoryName) {
-		return new CreateCategoryResponse(id, categoryName);
+	public static CreateCategoryResponse of(long categoryId, String categoryName) {
+		return new CreateCategoryResponse(categoryId, categoryName);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/UpdateCategoryResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/presentation/dto/response/UpdateCategoryResponse.java
@@ -3,7 +3,7 @@ package com.pinback.pinback_server.domain.category.presentation.dto.response;
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
 
 public record UpdateCategoryResponse(
-	long id,
+	long categoryId,
 	String categoryName
 ) {
 	public static UpdateCategoryResponse from(Category category) {


### PR DESCRIPTION
## 🚀 PR 요약

카테고리 생성 및 수정 시 응답 DTO 필드명을 id에서 categoryId로 변경합니다.

## ✨ PR 상세 내용



## 🚨 주의 사항

없습니다.

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?
