### PR TITLE
feat: 알림 테스트 API 구현

### DIFF
--- a/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
@@ -1,0 +1,18 @@
+package com.pinback.pinback_server.domain.test.application;
+
+import org.springframework.stereotype.Service;
+
+import com.pinback.pinback_server.domain.test.presentation.dto.request.PushTestRequest;
+import com.pinback.pinback_server.infra.firebase.FcmService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TestUsecase {
+	private final FcmService fcmService;
+
+	public void pushTest(PushTestRequest request) {
+		fcmService.sendNotification(request.fcmToken(), request.message());
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/test/presentation/TestController.java
+++ b/src/main/java/com/pinback/pinback_server/domain/test/presentation/TestController.java
@@ -1,0 +1,26 @@
+package com.pinback.pinback_server.domain.test.presentation;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pinback.pinback_server.domain.test.application.TestUsecase;
+import com.pinback.pinback_server.domain.test.presentation.dto.request.PushTestRequest;
+import com.pinback.pinback_server.global.common.dto.ResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/test")
+@RequiredArgsConstructor
+public class TestController {
+	private final TestUsecase testUsecase;
+
+	@PostMapping("/push")
+	public ResponseDto<Void> pushTest(@RequestBody PushTestRequest pushTestRequest) {
+		testUsecase.pushTest(pushTestRequest);
+
+		return ResponseDto.ok();
+	}
+}

--- a/src/main/java/com/pinback/pinback_server/domain/test/presentation/dto/request/PushTestRequest.java
+++ b/src/main/java/com/pinback/pinback_server/domain/test/presentation/dto/request/PushTestRequest.java
@@ -1,0 +1,7 @@
+package com.pinback.pinback_server.domain.test.presentation.dto.request;
+
+public record PushTestRequest(
+	String fcmToken,
+	String message
+) {
+}

--- a/src/main/java/com/pinback/pinback_server/global/config/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/pinback/pinback_server/global/config/auth/filter/JwtAuthenticationFilter.java
@@ -98,6 +98,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				path.equals("/health") ||
 				path.startsWith("/swagger") ||
 				path.startsWith("/v3/api-docs") ||
-				path.startsWith("/docs");
+				path.startsWith("/docs") ||
+				path.startsWith("/api/v1/test/push");
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/global/config/cors/CorsConfig.java
+++ b/src/main/java/com/pinback/pinback_server/global/config/cors/CorsConfig.java
@@ -19,7 +19,9 @@ public class CorsConfig {
 		configuration.setAllowedOriginPatterns(List.of(
 			"http://localhost:3000",
 			"http://localhost:3001",
-			"chrome-extension://*"
+			"chrome-extension://*",
+			"http://localhost:5173",
+			"http://localhost:5174"
 		));
 
 		configuration.setAllowedMethods(Arrays.asList(

--- a/src/main/java/com/pinback/pinback_server/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/pinback/pinback_server/global/config/security/SecurityConfig.java
@@ -55,6 +55,10 @@ public class SecurityConfig {
 					"/api/v1/auth/token"
 				).permitAll()
 
+				.requestMatchers(
+					"/api/v1/test/*"
+				).permitAll()
+
 				.anyRequest().authenticated()
 			)
 			.formLogin(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## 🚀 PR 요약

#61 알림 테스트 API를 구현했습니다.

## ✨ PR 상세 내용

클라이언트 테스트 용도로 알림 테스트 API 를 구현했습니다. 

## 🚨 주의 사항

없습니다

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?

close #61 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint for sending test push notifications.
  * Introduced support for sending push notifications by providing an FCM token and message.

* **Bug Fixes**
  * None.

* **Chores**
  * Updated security and authentication settings to allow unauthenticated access to the new test push notification endpoint.
  * Expanded CORS configuration to support additional localhost origins for development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->