### PR TITLE
feat: 카테고리 생성 테스트 API 구현

### DIFF
--- a/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service;
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.category.domain.service.CategoryGetService;
 import com.pinback.pinback_server.domain.category.domain.service.CategorySaveService;
-import com.pinback.pinback_server.domain.category.exception.CategoryAlreadyExistException;
 import com.pinback.pinback_server.domain.category.exception.CategoryLimitOverException;
 import com.pinback.pinback_server.domain.test.presentation.dto.request.PushTestRequest;
 import com.pinback.pinback_server.domain.test.presentation.dto.response.CategoriesTestResponse;
@@ -53,9 +52,6 @@ public class TestUsecase {
 
 		List<Category> createdCategories = defaultCategoryNames.stream()
 			.map(categoryName -> {
-				if (categoryGetService.checkExistsByCategoryNameAndUser(categoryName, getUser)) {
-					throw new CategoryAlreadyExistException();
-				}
 				Category category = Category.create(categoryName, getUser);
 				return categorySaveService.save(category);
 			})

--- a/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
@@ -32,10 +32,7 @@ public class TestUsecase {
 	}
 
 	public CategoriesTestResponse categoriesTest(User user) {
-		// 유저 확인
 		User getUser = userGetService.getUser(user.getId());
-
-		// 카테고리 10개 생성 + 리스트에 추가
 		List<String> defaultCategoryNames = Arrays.asList(
 			"집",
 			"취업",

--- a/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
@@ -1,8 +1,16 @@
 package com.pinback.pinback_server.domain.test.application;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.category.domain.service.CategorySaveService;
 import com.pinback.pinback_server.domain.test.presentation.dto.request.PushTestRequest;
+import com.pinback.pinback_server.domain.test.presentation.dto.response.CategoriesTestResponse;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
+import com.pinback.pinback_server.domain.user.domain.service.UserGetService;
 import com.pinback.pinback_server.infra.firebase.FcmService;
 
 import lombok.RequiredArgsConstructor;
@@ -11,8 +19,41 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TestUsecase {
 	private final FcmService fcmService;
+	private final UserGetService userGetService;
+	private final CategorySaveService categorySaveService;
 
 	public void pushTest(PushTestRequest request) {
 		fcmService.sendNotification(request.fcmToken(), request.message());
+	}
+
+	public CategoriesTestResponse categoriesTest(User user) {
+		// 유저 확인
+		User getUser = userGetService.getUser(user.getId());
+
+		// 카테고리 10개 생성 + 리스트에 추가
+		List<String> defaultCategoryNames = Arrays.asList(
+			"집",
+			"취업",
+			"동아리",
+			"자기계발",
+			"포트폴리오",
+			"경제시사흐름",
+			"최신기술트렌드",
+			"인성직무면접꿀팁",
+			"어학자격증취득준비",
+			"멘탈관리스트레스해소"
+		);
+		List<Category> createdCategories = defaultCategoryNames.stream()
+			.map(categoryName -> {
+				Category category = Category.create(categoryName, user);
+				return categorySaveService.save(category);
+			})
+			.toList();
+
+		List<String> savedCategoryNames = createdCategories.stream()
+			.map(Category::getName)
+			.toList();
+
+		return CategoriesTestResponse.of(savedCategoryNames);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/test/presentation/TestController.java
+++ b/src/main/java/com/pinback/pinback_server/domain/test/presentation/TestController.java
@@ -7,10 +7,15 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.pinback.pinback_server.domain.test.application.TestUsecase;
 import com.pinback.pinback_server.domain.test.presentation.dto.request.PushTestRequest;
+import com.pinback.pinback_server.domain.test.presentation.dto.response.CategoriesTestResponse;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
+import com.pinback.pinback_server.global.common.annotation.CurrentUser;
 import com.pinback.pinback_server.global.common.dto.ResponseDto;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/test")
 @RequiredArgsConstructor
@@ -22,5 +27,14 @@ public class TestController {
 		testUsecase.pushTest(pushTestRequest);
 
 		return ResponseDto.ok();
+	}
+
+	@PostMapping("/categories")
+	public ResponseDto<CategoriesTestResponse> categoriesTest(
+		@CurrentUser User user
+	) {
+		CategoriesTestResponse response = testUsecase.categoriesTest(user);
+		log.info("categoriesTest: {}", response);
+		return ResponseDto.ok(response);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/test/presentation/TestController.java
+++ b/src/main/java/com/pinback/pinback_server/domain/test/presentation/TestController.java
@@ -13,9 +13,7 @@ import com.pinback.pinback_server.global.common.annotation.CurrentUser;
 import com.pinback.pinback_server.global.common.dto.ResponseDto;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @RestController
 @RequestMapping("/api/v1/test")
 @RequiredArgsConstructor
@@ -34,7 +32,6 @@ public class TestController {
 		@CurrentUser User user
 	) {
 		CategoriesTestResponse response = testUsecase.categoriesTest(user);
-		log.info("categoriesTest: {}", response);
 		return ResponseDto.ok(response);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/test/presentation/dto/response/CategoriesTestResponse.java
+++ b/src/main/java/com/pinback/pinback_server/domain/test/presentation/dto/response/CategoriesTestResponse.java
@@ -1,0 +1,11 @@
+package com.pinback.pinback_server.domain.test.presentation.dto.response;
+
+import java.util.List;
+
+public record CategoriesTestResponse(
+	List<String> categories
+) {
+	public static CategoriesTestResponse of(List<String> categories) {
+		return new CategoriesTestResponse(categories);
+	}
+}


### PR DESCRIPTION
## 🚀 PR 요약

카테고리 10개를 생성하는 테스트 API를 구현합니다.

## ✨ PR 상세 내용

1~10자 내외의 10개의 카테고리를 생성합니다.

## 🚨 주의 사항

없습니다.

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to generate and return a list of default category names for the authenticated user.
  * Introduced a response format that provides the list of categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->