### PR TITLE
feat: 아티클 목업 데이터 생성 로직 구현

### DIFF
--- a/src/main/java/com/pinback/pinback_server/domain/notification/domain/entity/PushSubscription.java
+++ b/src/main/java/com/pinback/pinback_server/domain/notification/domain/entity/PushSubscription.java
@@ -35,7 +35,7 @@ public class PushSubscription extends BaseEntity {
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
-	@Column(name = "endpoint", nullable = false, unique = true)
+	@Column(name = "token", nullable = false, unique = true)
 	private String token;
 
 	public static PushSubscription from(User user, String token) {

--- a/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
@@ -1,8 +1,15 @@
 package com.pinback.pinback_server.domain.test.application;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 
+import com.pinback.pinback_server.domain.article.domain.entity.Article;
+import com.pinback.pinback_server.domain.article.domain.service.ArticleSaveService;
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
+import com.pinback.pinback_server.domain.category.domain.service.CategoryGetService;
 import com.pinback.pinback_server.domain.test.presentation.dto.request.PushTestRequest;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
 import com.pinback.pinback_server.infra.firebase.FcmService;
 
 import lombok.RequiredArgsConstructor;
@@ -11,8 +18,21 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TestUsecase {
 	private final FcmService fcmService;
+	private final CategoryGetService categoryGetService;
+	private final ArticleSaveService articleSaveService;
 
 	public void pushTest(PushTestRequest request) {
 		fcmService.sendNotification(request.fcmToken(), request.message());
 	}
+
+	public void createByCategory(User user, long categoryId) {
+		Category category = categoryGetService.findById(categoryId);
+
+		for (int i = 0; i < 5; i++) {
+			articleSaveService.save(Article.create(
+				UUID.randomUUID().toString(), "testMemo", user, category, null
+			));
+		}
+	}
+
 }

--- a/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
@@ -26,11 +26,12 @@ public class TestUsecase {
 	}
 
 	public void createByCategory(User user, long categoryId) {
+		String format = "%s:%s";
 		Category category = categoryGetService.findById(categoryId);
 
 		for (int i = 0; i < 5; i++) {
 			articleSaveService.save(Article.create(
-				UUID.randomUUID().toString(), "testMemo", user, category, null
+				String.format(format, user.getEmail(), UUID.randomUUID()), "testMemo", user, category, null
 			));
 		}
 	}

--- a/src/main/java/com/pinback/pinback_server/domain/test/presentation/TestController.java
+++ b/src/main/java/com/pinback/pinback_server/domain/test/presentation/TestController.java
@@ -3,10 +3,13 @@ package com.pinback.pinback_server.domain.test.presentation;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.pinback.pinback_server.domain.test.application.TestUsecase;
 import com.pinback.pinback_server.domain.test.presentation.dto.request.PushTestRequest;
+import com.pinback.pinback_server.domain.user.domain.entity.User;
+import com.pinback.pinback_server.global.common.annotation.CurrentUser;
 import com.pinback.pinback_server.global.common.dto.ResponseDto;
 
 import lombok.RequiredArgsConstructor;
@@ -20,6 +23,16 @@ public class TestController {
 	@PostMapping("/push")
 	public ResponseDto<Void> pushTest(@RequestBody PushTestRequest pushTestRequest) {
 		testUsecase.pushTest(pushTestRequest);
+
+		return ResponseDto.ok();
+	}
+
+	@PostMapping("/articles")
+	public ResponseDto<Void> createArticles(
+		@CurrentUser User user,
+		@RequestParam Long categoryId
+	) {
+		testUsecase.createByCategory(user, categoryId);
 
 		return ResponseDto.ok();
 	}


### PR DESCRIPTION
## 🚀 PR 요약

카테고리를 입력받아 해당 카테고리의 아티클 목업데이터를 생성하는 로직을 구현했습니다. 

## ✨ PR 상세 내용

1. 카테고리를 입력하면 해당 카테고리의 아티클을 만듭니다
2. 이때 url은 `email:랜덤UUID` 로 설정됩니다.
3. 한번에 다섯개의 아티클을 생성합니다.
<img width="410" height="140" alt="image" src="https://github.com/user-attachments/assets/42685957-2d96-4535-bf59-d7b4ad188033" />

url 예시입니당

## 🚨 주의 사항

원래 실제 사용하는 사이트 주소를 넣으려고 했으나, 랜덤 url 로직이 복잡해서 제외했습니다. 
필요한 경우 테스트 API가 아닌 POST `/articles` 를 사용하는 방향으로 하면 좋을 것 같아요

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new POST endpoint to create multiple articles for a selected category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->