### PR TITLE
fix: 카테고리 삭제 시 아티클도 함께 삭제되도록 기능 수정

### DIFF
--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepository.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.pinback.pinback_server.domain.article.domain.entity.Article;
-import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
 
 @Repository
@@ -22,6 +21,4 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Article
 	Optional<Article> findArticleByUserAndUrl(User user, String url);
 
 	Optional<Article> findArticleByUserAndId(User user, Long id);
-
-	void deleteByUserAndCategory(User user, Category category);
 }

--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepositoryCustom.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepositoryCustom.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 
 import com.pinback.pinback_server.domain.article.domain.entity.Article;
 import com.pinback.pinback_server.domain.article.domain.repository.dto.ArticlesWithUnreadCount;
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
 
 public interface ArticleRepositoryCustom {
 	ArticlesWithUnreadCount findAllCustom(UUID userId, Pageable pageable);
@@ -17,4 +18,6 @@ public interface ArticleRepositoryCustom {
 	Page<Article> findTodayRemind(UUID userId, Pageable pageable, LocalDateTime startAt, LocalDateTime endAt);
 
 	ArticlesWithUnreadCount findAllByIsReadFalse(UUID userId, Pageable pageable);
+
+	void deleteByUserAndCategory(UUID userId, Category category);
 }

--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepositoryCustom.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepositoryCustom.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Pageable;
 
 import com.pinback.pinback_server.domain.article.domain.entity.Article;
 import com.pinback.pinback_server.domain.article.domain.repository.dto.ArticlesWithUnreadCount;
-import com.pinback.pinback_server.domain.category.domain.entity.Category;
 
 public interface ArticleRepositoryCustom {
 	ArticlesWithUnreadCount findAllCustom(UUID userId, Pageable pageable);
@@ -19,5 +18,5 @@ public interface ArticleRepositoryCustom {
 
 	ArticlesWithUnreadCount findAllByIsReadFalse(UUID userId, Pageable pageable);
 
-	void deleteByUserAndCategory(UUID userId, Category category);
+	void deleteByUserAndCategory(UUID userId, long categoryId);
 }

--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepositoryCustomImpl.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Repository;
 
 import com.pinback.pinback_server.domain.article.domain.entity.Article;
 import com.pinback.pinback_server.domain.article.domain.repository.dto.ArticlesWithUnreadCount;
-import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -138,8 +137,8 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
 	}
 
 	@Override
-	public void deleteByUserAndCategory(UUID userId, Category category) {
-		BooleanExpression conditions = article.user.id.eq(userId).and(article.category.eq(category));
+	public void deleteByUserAndCategory(UUID userId, long categoryId) {
+		BooleanExpression conditions = article.user.id.eq(userId).and(article.category.id.eq(categoryId));
 
 		queryFactory
 			.delete(article)

--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/repository/ArticleRepositoryCustomImpl.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Repository;
 
 import com.pinback.pinback_server.domain.article.domain.entity.Article;
 import com.pinback.pinback_server.domain.article.domain.repository.dto.ArticlesWithUnreadCount;
+import com.pinback.pinback_server.domain.category.domain.entity.Category;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -134,5 +135,15 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
 
 		return new ArticlesWithUnreadCount(unReadCount,
 			PageableExecutionUtils.getPage(articles, pageable, countQuery::fetchOne));
+	}
+
+	@Override
+	public void deleteByUserAndCategory(UUID userId, Category category) {
+		BooleanExpression conditions = article.user.id.eq(userId).and(article.category.eq(category));
+
+		queryFactory
+			.delete(article)
+			.where(conditions)
+			.execute();
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/service/ArticleDeleteService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/service/ArticleDeleteService.java
@@ -7,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.pinback.pinback_server.domain.article.domain.entity.Article;
 import com.pinback.pinback_server.domain.article.domain.repository.ArticleRepository;
-import com.pinback.pinback_server.domain.category.domain.entity.Category;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,8 +20,8 @@ public class ArticleDeleteService {
 		articleRepository.delete(article);
 	}
 
-	public void deleteByCategory(UUID userId, Category category) {
-		articleRepository.deleteByUserAndCategory(userId, category);
+	public void deleteByCategory(UUID userId, long categoryId) {
+		articleRepository.deleteByUserAndCategory(userId, categoryId);
 	}
 
 }

--- a/src/main/java/com/pinback/pinback_server/domain/article/domain/service/ArticleDeleteService.java
+++ b/src/main/java/com/pinback/pinback_server/domain/article/domain/service/ArticleDeleteService.java
@@ -1,12 +1,13 @@
 package com.pinback.pinback_server.domain.article.domain.service;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.pinback.pinback_server.domain.article.domain.entity.Article;
 import com.pinback.pinback_server.domain.article.domain.repository.ArticleRepository;
 import com.pinback.pinback_server.domain.category.domain.entity.Category;
-import com.pinback.pinback_server.domain.user.domain.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,8 +21,8 @@ public class ArticleDeleteService {
 		articleRepository.delete(article);
 	}
 
-	public void deleteByCategory(User user, Category category) {
-		articleRepository.deleteByUserAndCategory(user, category);
+	public void deleteByCategory(UUID userId, Category category) {
+		articleRepository.deleteByUserAndCategory(userId, category);
 	}
 
 }

--- a/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
@@ -103,7 +103,7 @@ public class CategoryManagementUsecase {
 		Category category = categoryGetService.findById(categoryId);
 		checkOwner(category, user);
 		User getUser = userGetService.getUser(user.getId());
-		articleDeleteService.deleteByCategory(getUser.getId(), category);
+		articleDeleteService.deleteByCategory(getUser.getId(), category.getId());
 		categoryDeleteService.delete(category);
 	}
 

--- a/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
@@ -26,7 +26,6 @@ import com.pinback.pinback_server.domain.category.presentation.dto.response.Cate
 import com.pinback.pinback_server.domain.category.presentation.dto.response.CreateCategoryResponse;
 import com.pinback.pinback_server.domain.category.presentation.dto.response.UpdateCategoryResponse;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
-import com.pinback.pinback_server.domain.user.domain.service.UserGetService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +40,6 @@ public class CategoryManagementUsecase {
 	private final ArticleGetService articleGetService;
 	private final CategoryDeleteService categoryDeleteService;
 	private final ArticleDeleteService articleDeleteService;
-	private final UserGetService userGetService;
 
 	@Transactional
 	public CreateCategoryResponse createCategory(User user, CategoryCreateCommand command) {
@@ -102,8 +100,7 @@ public class CategoryManagementUsecase {
 	public void deleteCategory(final User user, final long categoryId) {
 		Category category = categoryGetService.findById(categoryId);
 		checkOwner(category, user);
-		User getUser = userGetService.getUser(user.getId());
-		articleDeleteService.deleteByCategory(getUser.getId(), category.getId());
+		articleDeleteService.deleteByCategory(user.getId(), category.getId());
 		categoryDeleteService.delete(category);
 	}
 

--- a/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/category/application/CategoryManagementUsecase.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.pinback.pinback_server.domain.article.domain.entity.Article;
+import com.pinback.pinback_server.domain.article.domain.service.ArticleDeleteService;
 import com.pinback.pinback_server.domain.article.domain.service.ArticleGetService;
 import com.pinback.pinback_server.domain.category.application.command.CategoryCreateCommand;
 import com.pinback.pinback_server.domain.category.application.command.CategoryUpdateCommand;
@@ -25,6 +26,7 @@ import com.pinback.pinback_server.domain.category.presentation.dto.response.Cate
 import com.pinback.pinback_server.domain.category.presentation.dto.response.CreateCategoryResponse;
 import com.pinback.pinback_server.domain.category.presentation.dto.response.UpdateCategoryResponse;
 import com.pinback.pinback_server.domain.user.domain.entity.User;
+import com.pinback.pinback_server.domain.user.domain.service.UserGetService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +40,8 @@ public class CategoryManagementUsecase {
 	private final CategoryGetService categoryGetService;
 	private final ArticleGetService articleGetService;
 	private final CategoryDeleteService categoryDeleteService;
+	private final ArticleDeleteService articleDeleteService;
+	private final UserGetService userGetService;
 
 	@Transactional
 	public CreateCategoryResponse createCategory(User user, CategoryCreateCommand command) {
@@ -98,6 +102,8 @@ public class CategoryManagementUsecase {
 	public void deleteCategory(final User user, final long categoryId) {
 		Category category = categoryGetService.findById(categoryId);
 		checkOwner(category, user);
+		User getUser = userGetService.getUser(user.getId());
+		articleDeleteService.deleteByCategory(getUser.getId(), category);
 		categoryDeleteService.delete(category);
 	}
 

--- a/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
@@ -83,6 +83,7 @@ public class TestUsecase {
 
 	public void deleteByCategory(User user, long categoryId) {
 		Category category = categoryGetService.findById(categoryId);
-		articleDeleteService.deleteByCategory(user, category);
+		User getUser = userGetService.getUser(user.getId());
+		articleDeleteService.deleteByCategory(getUser.getId(), category);
 	}
 }

--- a/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
+++ b/src/main/java/com/pinback/pinback_server/domain/test/application/TestUsecase.java
@@ -84,6 +84,6 @@ public class TestUsecase {
 	public void deleteByCategory(User user, long categoryId) {
 		Category category = categoryGetService.findById(categoryId);
 		User getUser = userGetService.getUser(user.getId());
-		articleDeleteService.deleteByCategory(getUser.getId(), category);
+		articleDeleteService.deleteByCategory(getUser.getId(), category.getId());
 	}
 }


### PR DESCRIPTION
## 🚀 PR 요약

기능 명세에 따라 카테고리 삭제 시 아티클도 함께 삭제되도록 카테고리 삭제 기능을 수정합니다.
querydsl을 사용하여 구현합니다.

## ✨ PR 상세 내용

이에 따라, 카테고리별 전체 아티클 삭제 시의 메서드도 변경합니다.

## 🚨 주의 사항

없습니다.

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated article deletion by category to use user and category IDs instead of entity objects.
  * Enhanced category deletion process to remove associated articles by user and category IDs.
  * Improved user retrieval before article deletion to ensure data consistency during category removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->