### PR TITLE
feat: 대시보드 조회시 사용자의 최초 가입일을 기준으로 요청일로 부터 3일이 지났는지 클라이언트에 반환한다.

### DIFF
--- a/api/src/main/java/com/pinback/api/article/controller/ArticleController.java
+++ b/api/src/main/java/com/pinback/api/article/controller/ArticleController.java
@@ -17,6 +17,7 @@ import com.pinback.api.article.dto.request.ArticleUpdateRequest;
 import com.pinback.application.article.dto.query.PageQuery;
 import com.pinback.application.article.dto.response.ArticleDetailResponse;
 import com.pinback.application.article.dto.response.ArticlesPageResponse;
+import com.pinback.application.article.dto.response.GetAllArticlesResponse;
 import com.pinback.application.article.dto.response.ReadArticleResponse;
 import com.pinback.application.article.dto.response.TodayRemindResponse;
 import com.pinback.application.article.port.in.CreateArticlePort;
@@ -77,13 +78,13 @@ public class ArticleController {
 
 	@Operation(summary = "모든 아티클 조회", description = "사용자의 모든 아티클을 페이징으로 조회합니다")
 	@GetMapping
-	public ResponseDto<ArticlesPageResponse> getAllArticles(
+	public ResponseDto<GetAllArticlesResponse> getAllArticles(
 		@Parameter(hidden = true) @CurrentUser User user,
 		@Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
 		@Parameter(description = "페이지 크기") @RequestParam(defaultValue = "8") int size
 	) {
 		PageQuery query = new PageQuery(page, size);
-		ArticlesPageResponse response = getArticlePort.getAllArticles(user, query);
+		GetAllArticlesResponse response = getArticlePort.getAllArticles(user, query);
 		return ResponseDto.ok(response);
 	}
 

--- a/application/src/main/java/com/pinback/application/article/dto/response/GetAllArticlesResponse.java
+++ b/application/src/main/java/com/pinback/application/article/dto/response/GetAllArticlesResponse.java
@@ -5,9 +5,10 @@ import java.util.List;
 public record GetAllArticlesResponse(
 	long totalArticle,
 	long totalUnreadArticle,
+	boolean isNewUser,
 	List<ArticleResponse> articles
 ) {
-	public static GetAllArticlesResponse of(long totalArticle, long totalUnreadArticle, List<ArticleResponse> articles) {
-		return new GetAllArticlesResponse(totalArticle, totalUnreadArticle, articles);
+	public static GetAllArticlesResponse of(long totalArticle, long totalUnreadArticle, boolean isNewUser, List<ArticleResponse> articles) {
+		return new GetAllArticlesResponse(totalArticle, totalUnreadArticle, isNewUser, articles);
 	}
 }

--- a/application/src/main/java/com/pinback/application/article/dto/response/GetAllArticlesResponse.java
+++ b/application/src/main/java/com/pinback/application/article/dto/response/GetAllArticlesResponse.java
@@ -1,0 +1,13 @@
+package com.pinback.application.article.dto.response;
+
+import java.util.List;
+
+public record GetAllArticlesResponse(
+	long totalArticle,
+	long totalUnreadArticle,
+	List<ArticleResponse> articles
+) {
+	public static GetAllArticlesResponse of(long totalArticle, long totalUnreadArticle, List<ArticleResponse> articles) {
+		return new GetAllArticlesResponse(totalArticle, totalUnreadArticle, articles);
+	}
+}

--- a/application/src/main/java/com/pinback/application/article/port/in/GetArticlePort.java
+++ b/application/src/main/java/com/pinback/application/article/port/in/GetArticlePort.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import com.pinback.application.article.dto.query.PageQuery;
 import com.pinback.application.article.dto.response.ArticleDetailResponse;
 import com.pinback.application.article.dto.response.ArticlesPageResponse;
+import com.pinback.application.article.dto.response.GetAllArticlesResponse;
 import com.pinback.application.article.dto.response.RemindArticlesResponse;
 import com.pinback.application.article.dto.response.TodayRemindResponse;
 import com.pinback.domain.user.entity.User;
@@ -14,7 +15,7 @@ public interface GetArticlePort {
 
 	ArticleDetailResponse checkArticleExists(User user, String url);
 
-	ArticlesPageResponse getAllArticles(User user, PageQuery query);
+	GetAllArticlesResponse getAllArticles(User user, PageQuery query);
 
 	ArticlesPageResponse getAllArticlesByCategory(User user, long categoryId, PageQuery query);
 

--- a/application/src/main/java/com/pinback/application/article/usecase/query/GetArticleUsecase.java
+++ b/application/src/main/java/com/pinback/application/article/usecase/query/GetArticleUsecase.java
@@ -56,9 +56,12 @@ public class GetArticleUsecase implements GetArticlePort {
 			.map(ArticleResponse::from)
 			.toList();
 
+		boolean isNewUser = user.isNewUser(LocalDateTime.now());
+
 		return GetAllArticlesResponse.of(
 			result.article().getTotalElements(),
 			result.unReadCount(),
+			isNewUser,
 			articleResponses
 		);
 	}

--- a/application/src/main/java/com/pinback/application/article/usecase/query/GetArticleUsecase.java
+++ b/application/src/main/java/com/pinback/application/article/usecase/query/GetArticleUsecase.java
@@ -15,6 +15,7 @@ import com.pinback.application.article.dto.query.PageQuery;
 import com.pinback.application.article.dto.response.ArticleDetailResponse;
 import com.pinback.application.article.dto.response.ArticleResponse;
 import com.pinback.application.article.dto.response.ArticlesPageResponse;
+import com.pinback.application.article.dto.response.GetAllArticlesResponse;
 import com.pinback.application.article.dto.response.RemindArticleResponse;
 import com.pinback.application.article.dto.response.TodayRemindResponse;
 import com.pinback.application.article.port.in.GetArticlePort;
@@ -47,7 +48,7 @@ public class GetArticleUsecase implements GetArticlePort {
 	}
 
 	@Override
-	public ArticlesPageResponse getAllArticles(User user, PageQuery query) {
+	public GetAllArticlesResponse getAllArticles(User user, PageQuery query) {
 		ArticlesWithUnreadCountDto result = articleGetServicePort.findAll(
 			user, PageRequest.of(query.pageNumber(), query.pageSize()));
 
@@ -55,7 +56,7 @@ public class GetArticleUsecase implements GetArticlePort {
 			.map(ArticleResponse::from)
 			.toList();
 
-		return ArticlesPageResponse.of(
+		return GetAllArticlesResponse.of(
 			result.article().getTotalElements(),
 			result.unReadCount(),
 			articleResponses

--- a/application/src/test/java/com/pinback/application/article/usecase/query/GetArticleUsecaseTest.java
+++ b/application/src/test/java/com/pinback/application/article/usecase/query/GetArticleUsecaseTest.java
@@ -25,6 +25,7 @@ import com.pinback.application.article.dto.RemindArticlesWithCountDto;
 import com.pinback.application.article.dto.query.PageQuery;
 import com.pinback.application.article.dto.response.ArticleDetailResponse;
 import com.pinback.application.article.dto.response.ArticlesPageResponse;
+import com.pinback.application.article.dto.response.GetAllArticlesResponse;
 import com.pinback.application.article.dto.response.TodayRemindResponse;
 import com.pinback.application.article.port.out.ArticleGetServicePort;
 import com.pinback.application.category.port.in.GetCategoryPort;
@@ -50,6 +51,7 @@ class GetArticleUsecaseTest extends ApplicationTestBase {
 	void setUp() {
 		user = user();
 		ReflectionTestUtils.setField(user, "id", java.util.UUID.randomUUID());
+		ReflectionTestUtils.setField(user, "createdAt", LocalDateTime.now().minusDays(5));
 		category = categoryWithName(user, "테스트 카테고리");
 		ReflectionTestUtils.setField(category, "id", 1L);
 		article = articleWithDate(user, "https://test.com", category, LocalDateTime.of(2025, 8, 20, 15, 0));
@@ -119,7 +121,7 @@ class GetArticleUsecaseTest extends ApplicationTestBase {
 		when(articleGetServicePort.findAll(user, pageRequest)).thenReturn(dto);
 
 		// when
-		ArticlesPageResponse response = getArticleUsecase.getAllArticles(user, pageQuery);
+		GetAllArticlesResponse response = getArticleUsecase.getAllArticles(user, pageQuery);
 
 		// then
 		assertThat(response.articles()).hasSize(5);

--- a/application/src/test/java/com/pinback/application/article/usecase/query/GetArticleUsecaseTest.java
+++ b/application/src/test/java/com/pinback/application/article/usecase/query/GetArticleUsecaseTest.java
@@ -125,6 +125,7 @@ class GetArticleUsecaseTest extends ApplicationTestBase {
 
 		// then
 		assertThat(response.articles()).hasSize(5);
+		assertThat(response.isNewUser()).isNotNull();
 		verify(articleGetServicePort).findAll(user, pageRequest);
 	}
 

--- a/domain/src/main/java/com/pinback/domain/user/entity/User.java
+++ b/domain/src/main/java/com/pinback/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.pinback.domain.user.entity;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.UUID;
 
@@ -53,5 +54,9 @@ public class User extends BaseEntity {
 
 	public void updateRemindDefault(LocalTime newRemindDefault) {
 		this.remindDefault = newRemindDefault;
+	}
+
+	public boolean isNewUser(LocalDateTime now) {
+		return getCreatedAt().isAfter(now.minusDays(3));
 	}
 }


### PR DESCRIPTION
## 🚀 PR 요약

대시보드 조회시 사용자의 최초 가입일을 기준으로 요청일로 부터 3일이 지났는지 클라이언트에 반환하도록 코드를 작성했습니다.
close #95 

## ✨ PR 상세 내용

User는 LocalDateTime now를 받아 자신이 새로운 유저인지 판별하고 결과 값을 boolean으로 반환하도록 코드를 수정했습니다. 
모든 아티클 조회시 해당 결과값을 반영하도록 dto 필드를 수정했습니다. 

## 🚨 주의 사항

없습니다. 

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?
