### PR TITLE
fix: 카테고리별 아티클 조회시 조회조건 수정 

### DIFF
--- a/api/src/main/java/com/pinback/api/article/controller/ArticleController.java
+++ b/api/src/main/java/com/pinback/api/article/controller/ArticleController.java
@@ -1,6 +1,7 @@
 package com.pinback.api.article.controller;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -93,7 +94,7 @@ public class ArticleController {
 	public ResponseDto<ArticlesPageResponse> getAllArticlesByCategory(
 		@Parameter(hidden = true) @CurrentUser User user,
 		@Parameter(description = "카테고리 ID") @RequestParam Long categoryId,
-		@Parameter(description = "읽음 상태 (true: 읽음, false: 안읽음)", example = "true") @RequestParam(name = "read-status") boolean isRead,
+		@Parameter(description = "읽음 상태 (true: 읽음, false: 안읽음, 생략시: 전체)", example = "true") @RequestParam(name = "read-status", required = false) Boolean isRead,
 		@Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
 		@Parameter(description = "페이지 크기") @RequestParam(defaultValue = "8") int size
 	) {

--- a/application/src/main/java/com/pinback/application/article/dto/ArticlesWithUnreadCountDto.java
+++ b/application/src/main/java/com/pinback/application/article/dto/ArticlesWithUnreadCountDto.java
@@ -6,6 +6,7 @@ import com.pinback.domain.article.entity.Article;
 
 public record ArticlesWithUnreadCountDto(
 	Long unReadCount,
-	Page<Article> article
+	Page<Article> article,
+	Long totalCategoryArticleCount
 ) {
 }

--- a/application/src/main/java/com/pinback/application/article/port/in/GetArticlePort.java
+++ b/application/src/main/java/com/pinback/application/article/port/in/GetArticlePort.java
@@ -16,7 +16,7 @@ public interface GetArticlePort {
 
 	GetAllArticlesResponse getAllArticles(User user, PageQuery query);
 
-	ArticlesPageResponse getAllArticlesByCategory(User user, long categoryId, boolean isRead, PageQuery query);
+	ArticlesPageResponse getAllArticlesByCategory(User user, long categoryId, Boolean isRead, PageQuery query);
 
 	ArticlesPageResponse getUnreadArticles(User user, PageQuery query);
 

--- a/application/src/main/java/com/pinback/application/article/port/out/ArticleGetServicePort.java
+++ b/application/src/main/java/com/pinback/application/article/port/out/ArticleGetServicePort.java
@@ -26,7 +26,7 @@ public interface ArticleGetServicePort {
 
 	ArticlesWithUnreadCountDto findAll(User user, PageRequest pageRequest);
 
-	ArticlesWithUnreadCountDto findAllByCategory(User user, Category category, boolean isRead, PageRequest pageRequest);
+	ArticlesWithUnreadCountDto findAllByCategory(User user, Category category, Boolean isRead, PageRequest pageRequest);
 
 	ArticlesWithUnreadCountDto findUnreadArticles(User user, PageRequest pageRequest);
 

--- a/application/src/main/java/com/pinback/application/article/usecase/query/GetArticleUsecase.java
+++ b/application/src/main/java/com/pinback/application/article/usecase/query/GetArticleUsecase.java
@@ -67,7 +67,7 @@ public class GetArticleUsecase implements GetArticlePort {
 	}
 
 	@Override
-	public ArticlesPageResponse getAllArticlesByCategory(User user, long categoryId, boolean isRead, PageQuery query) {
+	public ArticlesPageResponse getAllArticlesByCategory(User user, long categoryId, Boolean isRead, PageQuery query) {
 		Category category = getCategoryPort.getCategoryAndUser(categoryId, user);
 
 		ArticlesWithUnreadCountDto result = articleGetServicePort.findAllByCategory(

--- a/application/src/main/java/com/pinback/application/article/usecase/query/GetArticleUsecase.java
+++ b/application/src/main/java/com/pinback/application/article/usecase/query/GetArticleUsecase.java
@@ -78,7 +78,7 @@ public class GetArticleUsecase implements GetArticlePort {
 			.toList();
 
 		return ArticlesPageResponse.of(
-			result.article().getTotalElements(),
+			result.totalCategoryArticleCount(),
 			result.unReadCount(),
 			articleResponses
 		);

--- a/application/src/test/java/com/pinback/application/article/usecase/query/GetArticleUsecaseTest.java
+++ b/application/src/test/java/com/pinback/application/article/usecase/query/GetArticleUsecaseTest.java
@@ -116,7 +116,7 @@ class GetArticleUsecaseTest extends ApplicationTestBase {
 
 		List<Article> articles = List.of(article, article, article, article, article);
 		Page<Article> articlePage = new PageImpl<>(articles, pageRequest, 5);
-		ArticlesWithUnreadCountDto dto = new ArticlesWithUnreadCountDto(3L, articlePage);
+		ArticlesWithUnreadCountDto dto = new ArticlesWithUnreadCountDto(3L, articlePage, null);
 
 		when(articleGetServicePort.findAll(user, pageRequest)).thenReturn(dto);
 
@@ -139,7 +139,7 @@ class GetArticleUsecaseTest extends ApplicationTestBase {
 
 		List<Article> articles = List.of(article, article, article);
 		Page<Article> articlePage = new PageImpl<>(articles, pageRequest, 3);
-		ArticlesWithUnreadCountDto dto = new ArticlesWithUnreadCountDto(3L, articlePage);
+		ArticlesWithUnreadCountDto dto = new ArticlesWithUnreadCountDto(3L, articlePage, 5L);
 
 		when(getCategoryPort.getCategoryAndUser(categoryId, user)).thenReturn(category);
 		when(articleGetServicePort.findAllByCategory(user, category, true, pageRequest)).thenReturn(dto);
@@ -162,7 +162,7 @@ class GetArticleUsecaseTest extends ApplicationTestBase {
 
 		List<Article> articles = List.of(article, article, article);
 		Page<Article> articlePage = new PageImpl<>(articles, pageRequest, 3);
-		ArticlesWithUnreadCountDto dto = new ArticlesWithUnreadCountDto(3L, articlePage);
+		ArticlesWithUnreadCountDto dto = new ArticlesWithUnreadCountDto(3L, articlePage, null);
 
 		when(articleGetServicePort.findUnreadArticles(user, pageRequest)).thenReturn(dto);
 

--- a/infrastructure/src/main/java/com/pinback/infrastructure/article/repository/ArticleRepositoryCustom.java
+++ b/infrastructure/src/main/java/com/pinback/infrastructure/article/repository/ArticleRepositoryCustom.java
@@ -13,7 +13,7 @@ import com.pinback.infrastructure.article.repository.dto.RemindArticlesWithCount
 public interface ArticleRepositoryCustom {
 	ArticlesWithUnreadCount findAllCustom(UUID userId, Pageable pageable);
 
-	ArticlesWithUnreadCount findAllByCategory(UUID userId, long articleId, boolean isRead, Pageable pageable);
+	ArticlesWithUnreadCount findAllByCategory(UUID userId, long articleId, Boolean isRead, Pageable pageable);
 
 	Page<Article> findTodayRemind(UUID userId, Pageable pageable, LocalDateTime startAt, LocalDateTime endAt,
 		Boolean isRead);

--- a/infrastructure/src/main/java/com/pinback/infrastructure/article/repository/ArticleRepositoryCustomImpl.java
+++ b/infrastructure/src/main/java/com/pinback/infrastructure/article/repository/ArticleRepositoryCustomImpl.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
@@ -54,7 +55,8 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
 			.fetchOne();
 
 		return new ArticlesWithUnreadCount(unReadCount,
-			PageableExecutionUtils.getPage(articles, pageable, countQuery::fetchOne));
+			PageableExecutionUtils.getPage(articles, pageable, countQuery::fetchOne),
+			null);
 	}
 
 	@Override
@@ -80,7 +82,7 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
 		JPAQuery<Long> countQuery = queryFactory
 			.select(article.count())
 			.from(article)
-			.where(article.user.id.eq(userId).and(article.category.id.eq(categoryId)));
+			.where(conditions);
 
 		Long unReadCount = queryFactory
 			.select(article.count())
@@ -90,8 +92,15 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
 				.and(article.isRead.isFalse()))
 			.fetchOne();
 
+		Long totalCategoryArticleCount = queryFactory
+			.select(article.count())
+			.from(article)
+			.where(article.user.id.eq(userId).and(article.category.id.eq(categoryId)))
+			.fetchOne();
+
 		return new ArticlesWithUnreadCount(unReadCount,
-			PageableExecutionUtils.getPage(articles, pageable, countQuery::fetchOne));
+			new PageImpl<>(articles, pageable, countQuery.fetchOne()),
+			totalCategoryArticleCount);
 	}
 
 	@Override
@@ -146,7 +155,8 @@ public class ArticleRepositoryCustomImpl implements ArticleRepositoryCustom {
 			.fetchOne();
 
 		return new ArticlesWithUnreadCount(unReadCount,
-			PageableExecutionUtils.getPage(articles, pageable, countQuery::fetchOne));
+			PageableExecutionUtils.getPage(articles, pageable, countQuery::fetchOne),
+			null);
 	}
 
 	@Override

--- a/infrastructure/src/main/java/com/pinback/infrastructure/article/repository/dto/ArticlesWithUnreadCount.java
+++ b/infrastructure/src/main/java/com/pinback/infrastructure/article/repository/dto/ArticlesWithUnreadCount.java
@@ -6,5 +6,6 @@ import com.pinback.domain.article.entity.Article;
 
 public record ArticlesWithUnreadCount(
 	Long unReadCount,
-	Page<Article> article) {
+	Page<Article> article,
+	Long totalCategoryArticleCount) {
 }

--- a/infrastructure/src/main/java/com/pinback/infrastructure/article/service/ArticleGetService.java
+++ b/infrastructure/src/main/java/com/pinback/infrastructure/article/service/ArticleGetService.java
@@ -94,7 +94,8 @@ public class ArticleGetService implements ArticleGetServicePort {
 	private ArticlesWithUnreadCountDto convertToDto(ArticlesWithUnreadCount infraResult) {
 		return new ArticlesWithUnreadCountDto(
 			infraResult.unReadCount(),
-			infraResult.article()
+			infraResult.article(),
+			infraResult.totalCategoryArticleCount()
 		);
 	}
 }

--- a/infrastructure/src/main/java/com/pinback/infrastructure/article/service/ArticleGetService.java
+++ b/infrastructure/src/main/java/com/pinback/infrastructure/article/service/ArticleGetService.java
@@ -54,7 +54,7 @@ public class ArticleGetService implements ArticleGetServicePort {
 	}
 
 	@Override
-	public ArticlesWithUnreadCountDto findAllByCategory(User user, Category category, boolean isRead,
+	public ArticlesWithUnreadCountDto findAllByCategory(User user, Category category, Boolean isRead,
 		PageRequest pageRequest) {
 		ArticlesWithUnreadCount infraResult = articleRepository.findAllByCategory(user.getId(), category.getId(),
 			isRead,


### PR DESCRIPTION
## 🚀 PR 요약

아티클 조회시 조회조건을 수정했습니다.

## ✨ PR 상세 내용

1. 카테고리별 아티클 조회시 유저와 join되지 않아 전체 아티클이 조회되는 현상 수정
2. 카테고리별 아티클 조회시 전체 아티클 개수의 condition 조건을 수정
3. 읽음 조건을 null true false 세가지를 받을 수 있도록 수정

## 🚨 주의 사항

주의할 부분이 무엇인가요? - 지우고 작성

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. feat: 기능 추가)
- [x] 변경 사항에 대한 테스트를 진행했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Category article lists now support an optional Read Status filter — choose All, Read, or Unread when viewing a category.
  * Clearing the filter shows all articles in the category without requiring a read-status selection.
  * Category views now include a total-articles count per category alongside unread counts for clearer context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->